### PR TITLE
Add Rust + frontend test suites, CI enforcement, and testability seams

### DIFF
--- a/.github/workflows/validate-desktop.yml
+++ b/.github/workflows/validate-desktop.yml
@@ -12,11 +12,72 @@ permissions:
   contents: read
 
 jobs:
+  test-rust:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      # quadrant-core itself now compiles credential-free; the top-level Tauri
+      # crate and the curseforge feature still read these at compile time, so
+      # workspace-wide builds need placeholder values.
+      QUADRANT_API_KEY: dev
+      QUADRANT_OAUTH2_CLIENT_ID: dev
+      QUADRANT_OAUTH2_CLIENT_SECRET: dev
+      ETERNAL_API_TOKEN: dev
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install Linux desktop dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libwebkit2gtk-4.1-dev xdg-utils libappindicator3-dev librsvg2-dev patchelf libsecret-1-dev
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - name: Check formatting
+        working-directory: src-tauri
+        run: cargo fmt --all --check
+
+      - name: Run Rust tests
+        working-directory: src-tauri
+        run: cargo test --workspace
+
+      # Non-blocking until the existing warning backlog is cleared; then
+      # switch to `-- -D warnings`.
+      - name: Clippy (advisory)
+        working-directory: src-tauri
+        run: cargo clippy --workspace --all-targets || true
+
+  test-frontend:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install frontend dependencies
+        run: bun install
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Run frontend tests
+        run: bun run test
+
   validate:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
-      # quadrant-core still uses compile-time env!() for these desktop-only
-      # credentials, so CI must provide placeholder values for every Rust build.
+      # The Tauri crate and the curseforge feature use compile-time env!()
+      # for these desktop-only credentials, so CI must provide placeholder
+      # values for every Rust build.
       QUADRANT_API_KEY: dev
       QUADRANT_OAUTH2_CLIENT_ID: dev
       QUADRANT_OAUTH2_CLIENT_SECRET: dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,16 @@ Three crates, layered:
 - Vite dev server is **fixed at port 1420** with `strictPort: true`. Vite ignores `src-tauri/**` for file watching.
 - On Linux, Tauri builds also need `libsecret-1-dev` (keyring).
 
-## No tests
-There are **no test suites** anywhere — no Jest, Vitest, `cargo test`, or CI test job. The only "verification" is building successfully. CI (`validate-desktop.yml`) just runs builds. When you change something, verify by building the affected side (`bun run build` for renderer, a Tauri/cargo build for Rust).
+## Tests
+See **[TESTING.md](TESTING.md)** for the full strategy. Quick reference:
+
+- **Rust**: `#[cfg(test)]` modules live next to the code in `quadrant-core`/`quadrant-host`. Run from `src-tauri/` with placeholder creds:
+  `QUADRANT_OAUTH2_CLIENT_ID=dev QUADRANT_OAUTH2_CLIENT_SECRET=dev ETERNAL_API_TOKEN=dev QUADRANT_API_KEY=dev cargo test --workspace`
+  (`quadrant-core` alone compiles credential-free.) DI is via `&impl SettingsStore/SecretStore/EventSink` port params, so tests pass hand-rolled fakes; I/O uses `tempfile`; HTTP uses `httpmock` against the `#[cfg(test)]` `QUADRANT_TEST_*_API_BASE` / runtime `QUADRANT_API_BASE_URL` seams (serialize on the module's test mutex + clear the shared cache).
+- **Frontend**: Vitest + React Testing Library + jsdom. `bun run test` (watch: `bun run test:watch`). Colocated `*.test.ts(x)`. Mock the Tauri boundary at the facade — `vi.mock("./desktop")` / `vi.mock("../../../tools")`; never mock `@tauri-apps/*`. `src/desktop/runtime.ts` exports `__setRuntimeForTests` to reset the memoized adapter.
+- **CI** (`validate-desktop.yml`): `test-rust` (cargo test + fmt --check + advisory clippy) and `test-frontend` (bun run test) run on every PR alongside the build jobs.
+
+When you change something, run the tests for the affected side and add coverage for new logic — don't consider a change verified by a successful build alone.
 
 ## Styling
 - **Tailwind CSS v4** (via PostCSS, not the Tailwind CLI). Config in `postcss.config.cjs`. Per-component `.css` files sit next to some pages/components.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,133 @@
+# Testing
+
+Quadrant Next is tested at three layers: Rust unit tests, Rust integration tests
+(HTTP + filesystem), and frontend unit/component tests. An end-to-end layer is
+designed but not yet built (see the end of this document).
+
+CI runs the whole suite on every pull request via `.github/workflows/validate-desktop.yml`
+(`test-rust` and `test-frontend` jobs), in parallel with the existing build jobs.
+
+## Running the tests
+
+### Rust
+
+From `src-tauri/`:
+
+```sh
+cargo test --workspace
+```
+
+`quadrant-core` compiles and tests **credential-free**. The top-level Tauri crate
+and the `curseforge` feature still read compile-time `env!()` credentials, so a
+full `--workspace` run needs placeholder values (any string works):
+
+```sh
+QUADRANT_API_KEY=dev QUADRANT_OAUTH2_CLIENT_ID=dev \
+QUADRANT_OAUTH2_CLIENT_SECRET=dev ETERNAL_API_TOKEN=dev \
+cargo test --workspace
+```
+
+To include the CurseForge provider tests, add the feature:
+
+```sh
+QUADRANT_API_KEY=dev QUADRANT_OAUTH2_CLIENT_ID=dev \
+QUADRANT_OAUTH2_CLIENT_SECRET=dev ETERNAL_API_TOKEN=dev \
+cargo test -p quadrant-core --features curseforge
+```
+
+Use the default (dev) profile — the `release` profile has fat LTO and is far too
+slow for tests. Also run `cargo fmt --all --check` before pushing.
+
+### Frontend
+
+From the repo root:
+
+```sh
+bun run test        # vitest run (one-shot, used in CI)
+bun run test:watch  # vitest (watch mode)
+```
+
+Runner: **Vitest** with `@vitejs/plugin-react` (React Compiler preset) + jsdom, so
+components compile and render exactly as in the app. Config: `vitest.config.ts`;
+setup: `src/test/setup.ts` (jest-dom matchers). Test files are colocated with the
+code as `*.test.ts` / `*.test.tsx`.
+
+## How the layers are built
+
+### Rust — dependency injection via ports
+
+`quadrant-core` takes its host services as `&impl Trait` parameters
+(`SettingsStore`, `SecretStore`, `EventSink`, `Shell`, `Notifier`, `RuntimeState`
+in `crates/quadrant-core/src/ports.rs`). Tests supply small hand-rolled fakes —
+there is **no mocking framework** and we don't add one. Examples of the fakes are
+inline in `config.rs`, `modpacks.rs`, and `account/id.rs`.
+
+- **Pure logic** (model conversions, serde round-trips, fingerprinting, name/path
+  validation, RSS parsing): tested directly with fixed inputs.
+- **Filesystem** (`modpacks.rs`, `mc_mod/cache.rs`): tested with `tempfile::tempdir()`.
+  Functions take `mc_folder: &Path`, so tests point them at a temp dir. `cache.rs`
+  reads a global cache dir; a `#[cfg(test)]` `QUADRANT_TEST_CACHE_DIR` override
+  seam redirects it (guarded by a test mutex).
+- **HTTP** (`mc_mod/modrinth.rs`, `mc_mod/curseforge.rs`, `account/*`): tested with
+  `httpmock`. Providers read their base URL from a `#[cfg(test)]` env seam
+  (`QUADRANT_TEST_MODRINTH_API_BASE`, `QUADRANT_TEST_CURSEFORGE_API_BASE`); the
+  account backend honors `QUADRANT_API_BASE_URL` at runtime. **Important:** these
+  tests share a process-global HTTP client + cache, so each must lock the module's
+  test mutex (`PROVIDER_HTTP_TEST_MUTEX` / `ACCOUNT_ENV_TEST_MUTEX`) and clear the
+  provider cache before asserting.
+
+`quadrant-host` tests (`crates/quadrant-host/src/lib.rs`) cover the concrete
+port implementations: `JsonFileStore` persistence, the keyring-free paths, and the
+`HostEventBridge` broadcast fan-out.
+
+The thin Tauri command layer (`src-tauri/src`) and the `quadrant-napi` bindings are
+deliberately not unit-tested — they are one-line delegations to `QuadrantHost`.
+
+### Frontend — mock the Tauri boundary at the facade
+
+All Tauri access funnels through `src/desktop/index.ts` (with a real `browserRuntime`
+fake in `src/desktop/browser.ts`). Feature code never imports `@tauri-apps/*`
+directly, so tests mock **the facade**, not the plugins:
+
+```ts
+vi.mock("./desktop", () => ({ invoke: ..., listen: ..., createDesktopStore: ... }));
+vi.mock("../../../tools", () => ({ getModpacks: ..., /* ... */ }));
+```
+
+Stub every named export the component imports, or the module mock breaks the import.
+Heavy child components (e.g. `ModpackView`, `Mod`) are stubbed to simple markers.
+`src/desktop/runtime.ts` exports `__setRuntimeForTests(adapter | undefined)` to
+inject a fake adapter or reset the memoized singleton between tests.
+
+- **Pure logic** — `modLoaders.ts`, `uiScale.ts`, extracted `deepLinks.ts`,
+  `snackbar.ts`, and `SearchPage/searchLogic.ts` are tested with no mocking.
+- **`tools.ts`** — tested with the `./desktop` facade mocked.
+- **Components** — tested with React Testing Library + `user-event`; async data
+  loads are awaited with `waitFor`.
+- **i18n** — `src/locales/locales.test.ts` asserts key parity across `en`/`tr`/`uk`
+  and no empty values, guarding against silent drift (`fallbackLng` masks missing
+  keys at runtime).
+
+## Adding tests
+
+- Match the existing idiom of the file/area you're touching. Rust files have no
+  `/** @format */` header; TS/TSX files do.
+- Prefer testing **behavior** (observable output) over implementation details.
+- When you add product logic, add coverage for it. A green build is not verification.
+- If a Rust function is hard to test because it does its own I/O or reads a global,
+  add a narrow injection seam (a `&Path`/base-URL parameter, or a `#[cfg(test)]`
+  env override) rather than reaching for a mocking framework.
+
+## Deferred: end-to-end tests
+
+An app-level E2E layer is planned but **not implemented yet**:
+
+- **Tooling**: `tauri-driver` + WebdriverIO driving the built app over the
+  webkit2gtk WebDriver. Linux/Windows only — there is no macOS WebDriver for Tauri.
+- **Scope**: a single smoke spec — the app boots (with placeholder creds), the main
+  page renders, page navigation works, and a settings toggle persists across a restart.
+- **CI**: a separate, non-required job (E2E is inherently flakier than unit tests),
+  needing `webkit2gtk-driver` + `xvfb` on the Linux runner.
+
+The unit and integration layers cover most of the real risk; build the E2E layer
+once they've stabilized.

--- a/bun.lock
+++ b/bun.lock
@@ -34,10 +34,14 @@
         "@rolldown/plugin-babel": "^0.2.3",
         "@tailwindcss/postcss": "4.3.2",
         "@tauri-apps/cli": "2.11.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "26.1.1",
         "@types/react": "19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "6.0.3",
+        "@vitest/coverage-v8": "^4.1.10",
         "autoprefixer": "10.5.2",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "10.7.0",
@@ -48,13 +52,15 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "17.7.0",
+        "jsdom": "^29.1.1",
         "postcss": "8.5.19",
         "prettier": "3.9.5",
         "prettier-eslint": "17.1.1",
         "tailwindcss": "4.3.2",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
         "typescript-eslint": "8.64.0",
         "vite": "8.1.4",
+        "vitest": "^4.1.10",
       },
     },
   },
@@ -62,7 +68,17 @@
     "@tailwindcss/oxide",
   ],
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -98,9 +114,25 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
     "@choochmeque/msixbundle-cli-win32": ["@choochmeque/msixbundle-cli-win32@1.1.11", "", { "os": "win32" }, "sha512-eT6hnDzYxTflsil/zhf5FNdHC3ip8JPr+Itgh9ULI2KdD3YhWd9PVeRRC5BFHZUKHHsOqW2SVcRvsU3rcfpqiQ=="],
 
     "@choochmeque/tauri-windows-bundle": ["@choochmeque/tauri-windows-bundle@0.1.28", "", { "dependencies": { "commander": "^15.0.0", "glob": "^13.0.6", "image-js": "^1.6.0" }, "optionalDependencies": { "@choochmeque/msixbundle-cli-win32": "^1.1.11" }, "bin": { "tauri-windows-bundle": "dist/cli.js" } }, "sha512-myr/hMcWI8ivQeI5eP75qqiYm4Pgn7NQ9Wz9Z0FNXmaEmrnLbPyX2EZggTvOfJsImLnarvU4eP6NYXo2gnAHPQ=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.1.0", "", {}, "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.9", "", { "dependencies": { "@csstools/color-helpers": "^6.1.0", "@csstools/css-calc": "^3.2.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.6", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -129,6 +161,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
     "@fabianlars/tauri-plugin-oauth": ["@fabianlars/tauri-plugin-oauth@2.1.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-KElVn5VWJ7FPTbWvZ38NNWsxTMQ4wKNnWSB75eIh/CwO0RLLNH1eL3POdulluiaS4f0TWGdkL9nlD2ZKhi8DIQ=="],
 
@@ -224,6 +258,8 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.21", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
@@ -308,7 +344,21 @@
 
     "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
@@ -344,47 +394,23 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.62.0", "", { "dependencies": { "@typescript-eslint/types": "8.62.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ=="],
 
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
-
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
-
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
-
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
-
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
-
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
-
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
-
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
-
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
-
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
-
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
-
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
-
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
-
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
-
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
-
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
-
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
-
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
-
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
-
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
-
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.10", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.10", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.10", "vitest": "4.1.10" }, "optionalPeers": ["@vitest/browser"] }, "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -394,7 +420,7 @@
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
-    "ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -416,7 +442,11 @@
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.5", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
@@ -434,6 +464,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.40", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw=="],
 
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
     "binary-search": ["binary-search@1.3.6", "", {}, "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
@@ -449,6 +481,8 @@
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@1.1.3", "", { "dependencies": { "ansi-styles": "^2.2.1", "escape-string-regexp": "^1.0.2", "has-ansi": "^2.0.0", "strip-ansi": "^3.0.0", "supports-color": "^2.0.0" } }, "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A=="],
 
@@ -468,9 +502,15 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
@@ -480,15 +520,21 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -498,6 +544,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
     "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
@@ -505,6 +553,8 @@
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-iterator-helpers": ["es-iterator-helpers@1.3.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.1", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.1.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.3.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.5", "math-intrinsics": "^1.1.0", "safe-array-concat": "^1.1.3" } }, "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -548,7 +598,11 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "fast-bmp": ["fast-bmp@4.0.1", "", { "dependencies": { "iobuffer": "^6.0.0" } }, "sha512-+KtMijJj+uA8Sl6EXAnhza7US7EXSY5Z9NeiJwT1wopVUksyLMXL5iFmn9FjY8FdkstOkpJI9RuEVXkGpIPSwg=="],
 
@@ -622,6 +676,8 @@
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
     "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "has-proto": ["has-proto@1.2.0", "", { "dependencies": { "dunder-proto": "^1.0.0" } }, "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ=="],
@@ -635,6 +691,10 @@
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
 
@@ -688,6 +748,8 @@
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
     "is-set": ["is-set@2.0.3", "", {}, "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="],
@@ -710,6 +772,12 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
@@ -718,7 +786,9 @@
 
     "js-priority-queue": ["js-priority-queue@0.1.5", "", {}, "sha512-2dPmJT4GbXUpob7AZDR1wFMKz3Biy6oW69mwt5PTtdeoOgDin1i0p5gUV9k0LFeUxDpwkfr+JGMZDpcprjiY5w=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -772,15 +842,23 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
-    "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdn-data": ["mdn-data@2.28.1", "", {}, "sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng=="],
 
     "median-quickselect": ["median-quickselect@1.0.1", "", {}, "sha512-/QL9ptNuLsdA68qO+2o10TKCyu621zwwTFdLvtu8rzRNKsn8zvuGoq/vDxECPyELFG8wu+BpyoMR9BnsJqfVZQ=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -850,6 +928,8 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
@@ -860,6 +940,8 @@
 
     "parenthesis": ["parenthesis@3.1.8", "", {}, "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="],
 
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -867,6 +949,8 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -906,9 +990,13 @@
 
     "react-is-19": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
 
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
@@ -929,6 +1017,8 @@
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -952,6 +1042,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "skia-canvas": ["skia-canvas@3.0.8", "", { "dependencies": { "detect-libc": "^2.1.1", "follow-redirects": "^1.15.11", "https-proxy-agent": "^7.0.6", "string-split-by": "^1.0.0" } }, "sha512-FSYKxp8Ng2vOeeOBiyPhnn6ui6FirPJXMyjk4PKl8N/OWzVrkMawUgY9zubIWHMdYtyWFn0gfX3QlRwg6HBmdg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -959,6 +1051,10 @@
     "ssim.js": ["ssim.js@3.5.0", "", {}, "sha512-Aj6Jl2z6oDmgYFFbQqK7fght19bXdOxY7Tj03nF+03M9gCBAjeIiO8/PlEGMfKDwYpw4q6iBqVq2YuREorGg/g=="],
 
     "stable-hash-x": ["stable-hash-x@0.2.0", "", {}, "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -980,9 +1076,13 @@
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
-    "supports-color": ["supports-color@2.0.0", "", {}, "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="],
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "synckit": ["synckit@0.11.13", "", { "dependencies": { "@pkgr/core": "^0.3.6" } }, "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg=="],
 
@@ -994,7 +1094,21 @@
 
     "tiff": ["tiff@7.1.3", "", { "dependencies": { "fflate": "^0.8.2", "iobuffer": "^6.0.0" } }, "sha512-YEEq3fT++2pdta/9P/vGG4QRMdZQoe6W6JNaWnIi6NvAsbeNITwFCtmWwL/BZvOi+uo2I3ohyOkD3sZfme+c6g=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tldts": ["tldts@7.4.8", "", { "dependencies": { "tldts-core": "^7.4.8" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A=="],
+
+    "tldts-core": ["tldts-core@7.4.8", "", {}, "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw=="],
+
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
@@ -1018,13 +1132,15 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
-    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.64.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.64.0", "@typescript-eslint/parser": "8.64.0", "@typescript-eslint/typescript-estree": "8.64.0", "@typescript-eslint/utils": "8.64.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ=="],
 
     "uint8-base64": ["uint8-base64@1.0.0", "", {}, "sha512-B6ZJfEZL2FAhbIyZZ7WlQq8MPq1X1P1DUA//LsSv/vB4r+Dao5/BPoxgw2t+t1XyvoSfBkE7zI4SYsnGj7BmlQ=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -1036,9 +1152,19 @@
 
     "vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
 
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
     "vue-eslint-parser": ["vue-eslint-parser@10.4.1", "", { "dependencies": { "debug": "^4.4.0", "eslint-scope": "^8.2.0 || ^9.0.0", "eslint-visitor-keys": "^4.2.0 || ^5.0.0", "espree": "^10.3.0 || ^11.0.0", "esquery": "^1.6.0", "semver": "^7.6.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0" } }, "sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1050,7 +1176,13 @@
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -1059,6 +1191,8 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/helper-compilation-targets/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
@@ -1102,6 +1236,12 @@
 
     "@tauri-apps/plugin-updater/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "@typescript-eslint/eslint-plugin/@typescript-eslint/parser": ["@typescript-eslint/parser@8.64.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.64.0", "@typescript-eslint/types": "8.64.0", "@typescript-eslint/typescript-estree": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw=="],
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.64.0", "", { "dependencies": { "@typescript-eslint/types": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0" } }, "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w=="],
@@ -1130,6 +1270,10 @@
 
     "chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
+    "chalk/supports-color": ["supports-color@2.0.0", "", {}, "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="],
+
+    "css-tree/mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
@@ -1142,13 +1286,27 @@
 
     "eslint-plugin-react/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "has-ansi/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
+
+    "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "magicast/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "ml-random/ml-xsadd": ["ml-xsadd@2.0.0", "", {}, "sha512-VoAYUqmPRmzKbbqRejjqceGFp3VF81Qe8XXFGU0UXLxB7Mf4GGvyGq5Qn3k4AiQgDEV6WzobqlPOd+j0+m6IrA=="],
+
+    "path-scurry/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "prettier-eslint/eslint": ["eslint@10.6.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg=="],
 
     "prettier-eslint/prettier": ["prettier@3.9.0", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-LjIqSIC5VYLzs9WedVmJ2ljNAGnU+DteIClbahu4L/DBeWjZ6iT/k1lAYyu9JUh+1xINxWadaPw/Pl63y/agAw=="],
 
+    "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.18", "", {}, "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
@@ -1160,6 +1318,8 @@
 
     "vite/rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
+    "vitest/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
     "vue-eslint-parser/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.14", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA=="],
@@ -1169,6 +1329,8 @@
     "@babel/helper-compilation-targets/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.331", "", {}, "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q=="],
 
     "@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
+
+    "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.64.0", "", {}, "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA=="],
 
@@ -1189,6 +1351,8 @@
     "eslint-plugin-jsx-a11y/minimatch/brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
 
     "eslint-plugin-react/minimatch/brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+
+    "magicast/@babel/parser/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.64.0", "", { "dependencies": { "@typescript-eslint/types": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0" } }, "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w=="],
 
@@ -1233,6 +1397,10 @@
     "eslint-plugin-jsx-a11y/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "eslint-plugin-react/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "magicast/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "magicast/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -92,6 +92,16 @@ export default defineConfig([
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
+      // Honor the underscore-prefix convention for intentionally-unused
+      // bindings (e.g. API-compat constructor params, ignored catch vars).
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
     },
   },
 ]);

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "prettier": "3.9.5",
     "prettier-eslint": "17.1.1",
     "tailwindcss": "4.3.2",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "typescript-eslint": "8.64.0",
     "vite": "8.1.4",
     "vitest": "^4.1.10"

--- a/src-tauri/crates/quadrant-core/src/account/id.rs
+++ b/src-tauri/crates/quadrant-core/src/account/id.rs
@@ -335,28 +335,6 @@ pub async fn oauth2_login(
     Ok(())
 }
 
-/// Fetches a single page of notification history from the Quadrant backend.
-pub async fn get_notification_history_page(
-    secret_store: &impl SecretStore,
-    user_agent: &str,
-    cursor: Option<&NotificationCursor>,
-    read: Option<bool>,
-    limit: Option<usize>,
-    include_modpack_sync: bool,
-) -> Result<NotificationHistoryResponse> {
-    get_notification_history_page_with_refresh(
-        secret_store,
-        user_agent,
-        cursor,
-        read,
-        limit,
-        include_modpack_sync,
-        env!("QUADRANT_OAUTH2_CLIENT_ID"),
-        env!("QUADRANT_OAUTH2_CLIENT_SECRET"),
-    )
-    .await
-}
-
 /// Fetches a single page of notification history and refreshes the token on demand.
 pub async fn get_notification_history_page_with_refresh(
     secret_store: &impl SecretStore,
@@ -394,26 +372,6 @@ pub async fn get_notification_history_page_with_refresh(
     }
 
     parse_notification_history_response(response).await
-}
-
-/// Fetches all notification history pages from the provided cursor onward.
-pub async fn get_notification_history_all_since(
-    secret_store: &impl SecretStore,
-    user_agent: &str,
-    cursor: Option<&NotificationCursor>,
-    read: Option<bool>,
-    include_modpack_sync: bool,
-) -> Result<(Vec<Notification>, NotificationCursor)> {
-    get_notification_history_all_since_with_refresh(
-        secret_store,
-        user_agent,
-        cursor,
-        read,
-        include_modpack_sync,
-        env!("QUADRANT_OAUTH2_CLIENT_ID"),
-        env!("QUADRANT_OAUTH2_CLIENT_SECRET"),
-    )
-    .await
 }
 
 /// Fetches all notification history pages from the provided cursor onward.
@@ -551,8 +509,9 @@ pub async fn read_notification(
 #[cfg(test)]
 mod tests {
     use super::{
-        Notification, NotificationCursor, NotificationWsFrame, get_notification_history_all_since,
-        get_notification_history_page,
+        Notification, NotificationCursor, NotificationWsFrame,
+        get_notification_history_all_since_with_refresh,
+        get_notification_history_page_with_refresh,
     };
     use crate::{Result, ports::SecretStore};
     use httpmock::{Method::GET, MockServer};
@@ -613,7 +572,7 @@ mod tests {
             }));
         });
 
-        let response = get_notification_history_page(
+        let response = get_notification_history_page_with_refresh(
             &MemorySecretStore,
             "test-agent",
             Some(&NotificationCursor {
@@ -623,6 +582,8 @@ mod tests {
             None,
             Some(999),
             true,
+            "test-client-id",
+            "test-client-secret",
         )
         .await
         .unwrap();
@@ -667,7 +628,7 @@ mod tests {
             }));
         });
 
-        let (notifications, cursor) = get_notification_history_all_since(
+        let (notifications, cursor) = get_notification_history_all_since_with_refresh(
             &MemorySecretStore,
             "test-agent",
             Some(&NotificationCursor {
@@ -676,6 +637,8 @@ mod tests {
             }),
             None,
             true,
+            "test-client-id",
+            "test-client-secret",
         )
         .await
         .unwrap();

--- a/src-tauri/crates/quadrant-core/src/account/quadrant_settings_sync.rs
+++ b/src-tauri/crates/quadrant-core/src/account/quadrant_settings_sync.rs
@@ -124,12 +124,115 @@ pub async fn submit_quadrant_settings(
 
 #[cfg(test)]
 mod tests {
-    use super::SYNCED_KEYS;
+    use super::{SYNCED_KEYS, get_quadrant_settings, submit_quadrant_settings};
+    use crate::{
+        Result,
+        ports::{SecretStore, SettingsStore},
+    };
+    use httpmock::{
+        Method::{GET, POST},
+        MockServer,
+    };
+    use serde_json::Value;
+
+    struct MemorySettingsStore;
+
+    impl SettingsStore for MemorySettingsStore {
+        fn get_value(&self, key: &str) -> Result<Option<Value>> {
+            Ok(match key {
+                "lastSettingsUpdated" => {
+                    Some(Value::String("2024-01-01T00:00:00+00:00".to_string()))
+                }
+                "modrinth" => Some(Value::Bool(true)),
+                _ => None,
+            })
+        }
+
+        fn set_value(&self, _key: &str, _value: Value) -> Result<()> {
+            Ok(())
+        }
+
+        fn entries(&self) -> Result<Vec<(String, Value)>> {
+            Ok(vec![
+                ("modrinth".to_string(), Value::Bool(true)),
+                (
+                    "hardwareId".to_string(),
+                    Value::String("hw-123".to_string()),
+                ),
+            ])
+        }
+    }
+
+    struct MemorySecretStore;
+
+    impl SecretStore for MemorySecretStore {
+        fn get_secret(&self, key: &str) -> Result<Option<String>> {
+            match key {
+                "accountToken" => Ok(Some("token-123".to_string())),
+                _ => Ok(None),
+            }
+        }
+
+        fn set_secret(&self, _key: &str, _value: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn delete_secret(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn machine_identity_and_usage_counters_are_not_cloud_synced() {
         assert!(!SYNCED_KEYS.contains(&"hardwareId"));
         assert!(!SYNCED_KEYS.contains(&"curseforgeUsage"));
         assert!(!SYNCED_KEYS.contains(&"modrinthUsage"));
+    }
+
+    #[tokio::test]
+    async fn submit_quadrant_settings_surfaces_auth_failure_body() {
+        let _guard = crate::account::ACCOUNT_ENV_TEST_MUTEX.lock().unwrap();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_API_BASE_URL", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/quadrant/settings_sync/submit")
+                .header("authorization", "Bearer token-123");
+            then.status(401)
+                .header("content-type", "text/plain")
+                .body("invalid token");
+        });
+
+        let error =
+            submit_quadrant_settings(&MemorySettingsStore, &MemorySecretStore, "test-agent")
+                .await
+                .unwrap_err();
+        assert_eq!(error.to_string(), "invalid token");
+    }
+
+    #[tokio::test]
+    async fn get_quadrant_settings_errors_on_payload_without_sync_date() {
+        let _guard = crate::account::ACCOUNT_ENV_TEST_MUTEX.lock().unwrap();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_API_BASE_URL", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/quadrant/settings_sync/get")
+                .header("authorization", "Bearer token-123");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"settings":"{}"}"#);
+        });
+
+        let error = get_quadrant_settings(&MemorySettingsStore, &MemorySecretStore, "test-agent")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("sync_date missing"));
     }
 }

--- a/src-tauri/crates/quadrant-core/src/account/quadrant_share.rs
+++ b/src-tauri/crates/quadrant-core/src/account/quadrant_share.rs
@@ -278,4 +278,60 @@ mod tests {
         assert!(message.contains("Quadrant Share retrieval failed: invalid modpack payload"));
         assert!(message.contains("not-json"));
     }
+
+    #[tokio::test]
+    async fn share_modpack_raw_surfaces_invalid_json_success_body() {
+        let _guard = crate::account::ACCOUNT_ENV_TEST_MUTEX.lock().unwrap();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_API_BASE_URL", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST).path("/quadrant/share/submit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("{definitely-not-json");
+        });
+
+        let error = share_modpack_raw(
+            &MemorySettingsStore,
+            &EmptySecretStore,
+            "test-agent",
+            installed_modpack(),
+            "test-api-key",
+        )
+        .await
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("Quadrant Share submission failed: invalid JSON response"));
+        assert!(message.contains("{definitely-not-json"));
+    }
+
+    #[tokio::test]
+    async fn get_quadrant_share_modpack_surfaces_auth_failure() {
+        let _guard = crate::account::ACCOUNT_ENV_TEST_MUTEX.lock().unwrap();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_API_BASE_URL", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/quadrant/share/get")
+                .query_param("code", "abc123");
+            then.status(401)
+                .header("content-type", "text/plain")
+                .body("invalid api key");
+        });
+
+        let error = get_quadrant_share_modpack("test-agent", "test-api-key", "abc123".to_string())
+            .await
+            .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("Quadrant Share retrieval failed with 401 Unauthorized"));
+        assert!(message.contains("invalid api key"));
+    }
 }

--- a/src-tauri/crates/quadrant-core/src/account/quadrant_sync.rs
+++ b/src-tauri/crates/quadrant-core/src/account/quadrant_sync.rs
@@ -182,13 +182,16 @@ pub async fn answer_invite(
 
 #[cfg(test)]
 mod tests {
-    use super::sync_modpack;
+    use super::{get_synced_modpacks, sync_modpack};
     use crate::{
         Result,
         models::{InstalledMod, LocalModpack, ModLoader, ModSource},
         ports::SecretStore,
     };
-    use httpmock::{Method::POST, MockServer};
+    use httpmock::{
+        Method::{GET, POST},
+        MockServer,
+    };
 
     struct MemorySecretStore;
 
@@ -251,5 +254,57 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn sync_modpack_surfaces_auth_failure_body() {
+        let _guard = crate::account::ACCOUNT_ENV_TEST_MUTEX.lock().unwrap();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_API_BASE_URL", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/quadrant/sync/submit")
+                .header("authorization", "Bearer token-123");
+            then.status(401)
+                .header("content-type", "text/plain")
+                .body("invalid token");
+        });
+
+        let error = sync_modpack(
+            &MemorySecretStore,
+            "test-agent",
+            local_modpack(),
+            false,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.to_string(), "invalid token");
+    }
+
+    #[tokio::test]
+    async fn get_synced_modpacks_errors_on_malformed_payload() {
+        let _guard = crate::account::ACCOUNT_ENV_TEST_MUTEX.lock().unwrap();
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_API_BASE_URL", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/quadrant/sync/get")
+                .query_param("show_owners", "true")
+                .header("authorization", "Bearer token-123");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"unexpected":"shape"}"#);
+        });
+
+        get_synced_modpacks(&MemorySecretStore, "test-agent", true, None)
+            .await
+            .unwrap_err();
     }
 }

--- a/src-tauri/crates/quadrant-core/src/config.rs
+++ b/src-tauri/crates/quadrant-core/src/config.rs
@@ -275,6 +275,48 @@ mod tests {
     }
 
     #[test]
+    fn ensure_default_app_config_is_idempotent() {
+        let store = MemoryStore::new();
+        ensure_default_app_config(&store).unwrap();
+        let mut first = store.entries().unwrap();
+        first.sort_by(|a, b| a.0.cmp(&b.0));
+        assert!(!first.is_empty());
+
+        ensure_default_app_config(&store).unwrap();
+        let mut second = store.entries().unwrap();
+        second.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn ensure_default_app_config_preserves_existing_values() {
+        let store = MemoryStore::new();
+        store.set_bool("clipIcons", false).unwrap();
+        store.set_i64("uiScale", 150).unwrap();
+        store
+            .set_string("hardwareId", "fixed-id".to_string())
+            .unwrap();
+        store
+            .set_string("mcFolder", "/custom/minecraft".to_string())
+            .unwrap();
+
+        ensure_default_app_config(&store).unwrap();
+
+        assert_eq!(store.get_bool("clipIcons").unwrap(), Some(false));
+        assert_eq!(store.get_i64("uiScale").unwrap(), Some(150));
+        assert_eq!(
+            store.get_string("hardwareId").unwrap().as_deref(),
+            Some("fixed-id")
+        );
+        assert_eq!(
+            store.get_string("mcFolder").unwrap().as_deref(),
+            Some("/custom/minecraft")
+        );
+        assert_eq!(store.get_bool("modrinth").unwrap(), Some(true));
+        assert_eq!(store.get_i64("lastPage").unwrap(), Some(0));
+    }
+
+    #[test]
     fn mc_folder_resolves_to_minecraft_path() {
         let mc_folder = get_mc_folder().unwrap().unwrap();
         #[cfg(target_os = "macos")]

--- a/src-tauri/crates/quadrant-core/src/mc_mod/cache.rs
+++ b/src-tauri/crates/quadrant-core/src/mc_mod/cache.rs
@@ -10,6 +10,17 @@ use tokio::sync::Mutex;
 
 static CACHE_WRITE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
+fn cache_dir() -> PathBuf {
+    #[cfg(test)]
+    if let Ok(dir) = std::env::var("QUADRANT_TEST_CACHE_DIR") {
+        return PathBuf::from(dir);
+    }
+    dirs::cache_dir()
+        .unwrap_or_default()
+        .join("mrquantumoff.dev")
+        .join("QuadrantNextCache")
+}
+
 /// Cache index entry describing a downloaded file in the shared cache.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheIndex {
@@ -24,10 +35,7 @@ pub struct CacheIndex {
 /// Initializes the cache directory and removes stale cache entries.
 pub async fn init_cache() -> Result<(), anyhow::Error> {
     log::info!("Initializing mod cache");
-    let cache_dir = dirs::cache_dir()
-        .unwrap_or_default()
-        .join("mrquantumoff.dev")
-        .join("QuadrantNextCache");
+    let cache_dir = cache_dir();
     if !cache_dir.exists() {
         std::fs::create_dir_all(&cache_dir)?
     }
@@ -82,10 +90,7 @@ pub fn file_hash(file_bytes: &[u8]) -> String {
 
 /// Looks up a cached file by content hash.
 pub async fn get_cache_index(file_hash: String) -> Result<Option<CacheIndex>, anyhow::Error> {
-    let cache_dir = dirs::cache_dir()
-        .unwrap_or_default()
-        .join("mrquantumoff.dev")
-        .join("QuadrantNextCache");
+    let cache_dir = cache_dir();
     init_cache().await?;
     let cache_config = cache_dir.join("cacheIndex.json");
     let config_raw = std::fs::read_to_string(cache_config)?;
@@ -107,14 +112,11 @@ pub async fn add_cache_index(
     file_hash: String,
 ) -> Result<PathBuf, anyhow::Error> {
     let _guard = CACHE_WRITE_LOCK.lock().await;
-    let cache_dir = dirs::cache_dir()
-        .unwrap_or_default()
-        .join("mrquantumoff.dev")
-        .join("QuadrantNextCache");
-    if !cache_dir.exists() {
+    let cache_dir = cache_dir();
+    let cache_config = cache_dir.join("cacheIndex.json");
+    if !cache_config.exists() {
         init_cache().await?;
     }
-    let cache_config = cache_dir.join("cacheIndex.json");
     let config_raw = std::fs::read_to_string(&cache_config)?;
     let mut file_conts: Vec<CacheIndex> = serde_json::from_str(&config_raw)?;
 
@@ -155,4 +157,141 @@ pub async fn add_cache_index(
 
     std::fs::write(cache_config, serde_json::to_string_pretty(&file_conts)?)?;
     Ok(file_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CacheIndex, add_cache_index, file_hash, get_cache_index, init_cache};
+    use chrono::{Days, Utc};
+
+    static CACHE_ENV_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct CacheDirGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        _dir: tempfile::TempDir,
+    }
+
+    impl Drop for CacheDirGuard {
+        fn drop(&mut self) {
+            unsafe {
+                std::env::remove_var("QUADRANT_TEST_CACHE_DIR");
+            }
+        }
+    }
+
+    fn set_cache_dir() -> CacheDirGuard {
+        let lock = CACHE_ENV_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_CACHE_DIR", dir.path());
+        }
+        CacheDirGuard {
+            _lock: lock,
+            _dir: dir,
+        }
+    }
+
+    #[test]
+    fn file_hash_computes_sha1() {
+        assert_eq!(
+            file_hash(b"hello"),
+            "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
+        );
+        assert_eq!(file_hash(b""), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    }
+
+    #[tokio::test]
+    async fn add_and_get_cache_index_round_trip() {
+        let _guard = set_cache_dir();
+        let bytes = b"mod jar contents";
+        let hash = file_hash(bytes);
+
+        let path = add_cache_index("my mod.jar".to_string(), bytes, hash.clone())
+            .await
+            .unwrap();
+        assert!(path.exists());
+        assert_eq!(std::fs::read(&path).unwrap(), bytes);
+
+        let entry = get_cache_index(hash.clone()).await.unwrap().unwrap();
+        assert_eq!(entry.file_hash, hash);
+        assert_eq!(entry.file_name, path.to_string_lossy());
+
+        assert!(
+            get_cache_index("0000000000000000000000000000000000000000".to_string())
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_cache_index_refreshes_existing_entry_instead_of_duplicating() {
+        let _guard = set_cache_dir();
+        let bytes = b"same contents";
+        let hash = file_hash(bytes);
+
+        let first = add_cache_index("a.jar".to_string(), bytes, hash.clone())
+            .await
+            .unwrap();
+        let second = add_cache_index("b.jar".to_string(), bytes, hash.clone())
+            .await
+            .unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn init_cache_evicts_stale_and_missing_entries() {
+        let _guard = set_cache_dir();
+        let fresh = add_cache_index("fresh.jar".to_string(), b"fresh", file_hash(b"fresh"))
+            .await
+            .unwrap();
+
+        let stale = add_cache_index("stale.jar".to_string(), b"stale", file_hash(b"stale"))
+            .await
+            .unwrap();
+        let index_file = stale.parent().unwrap().join("cacheIndex.json");
+        let mut entries: Vec<CacheIndex> =
+            serde_json::from_str(&std::fs::read_to_string(&index_file).unwrap()).unwrap();
+        for entry in &mut entries {
+            if entry.file_hash == file_hash(b"stale") {
+                entry.last_used_date = Utc::now().checked_sub_days(Days::new(120)).unwrap();
+            }
+        }
+        std::fs::write(&index_file, serde_json::to_string_pretty(&entries).unwrap()).unwrap();
+
+        init_cache().await.unwrap();
+
+        assert!(fresh.exists());
+        assert!(!stale.exists());
+        assert!(
+            get_cache_index(file_hash(b"stale"))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            get_cache_index(file_hash(b"fresh"))
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn init_cache_recovers_from_corrupt_index() {
+        let _guard = set_cache_dir();
+        init_cache().await.unwrap();
+        let dir = std::path::PathBuf::from(std::env::var("QUADRANT_TEST_CACHE_DIR").unwrap());
+        std::fs::write(dir.join("cacheIndex.json"), "{not json").unwrap();
+
+        init_cache().await.unwrap();
+        assert!(
+            get_cache_index(file_hash(b"anything"))
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
 }

--- a/src-tauri/crates/quadrant-core/src/mc_mod/curseforge.rs
+++ b/src-tauri/crates/quadrant-core/src/mc_mod/curseforge.rs
@@ -624,6 +624,20 @@ mod tests {
     use serde_json::json;
     use tempfile::tempdir;
 
+    fn curseforge_search_args(query: &str) -> SearchModsArgs {
+        SearchModsArgs {
+            query: query.to_string(),
+            mod_type: "mod".to_string(),
+            filter_on: false,
+            game_version: String::new(),
+            mod_loader: String::new(),
+            categories: Vec::new(),
+            open_source: false,
+            sort_by: "relevance".to_string(),
+            offset: 0,
+        }
+    }
+
     fn curseforge_get_mod_args(id: &str) -> GetModArgs {
         GetModArgs {
             id: id.to_string(),
@@ -767,6 +781,254 @@ mod tests {
             std::env::remove_var("QUADRANT_TEST_CURSEFORGE_API_BASE");
         }
         clear_curseforge_fingerprint_cache().await;
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn search_mods_curseforge_serializes_query_and_pagination_params() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_CURSEFORGE_API_BASE", server.base_url());
+        }
+
+        let search = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/mods/search")
+                .header("x-api-key", env!("ETERNAL_API_TOKEN"))
+                .query_param("gameId", "432")
+                .query_param("searchFilter", "jei")
+                .query_param("sortField", "3")
+                .query_param("sortOrder", "desc")
+                .query_param("classId", "6")
+                .query_param("index", "50")
+                .query_param("pageSize", "50")
+                .query_param("gameVersion", "1.20.1")
+                .query_param("modLoaderType", "1")
+                .query_param("categoryIds", "[423,5191]");
+            then.status(200).json_body(json!({
+                "data": [{
+                    "id": 238222,
+                    "name": "Just Enough Items",
+                    "summary": "item viewer",
+                    "downloadCount": 999,
+                    "dateModified": "2024-01-01T00:00:00Z",
+                    "classId": 6,
+                    "slug": "jei",
+                    "screenshots": [{
+                        "thumbnailUrl": "https://example.invalid/screenshot.png"
+                    }],
+                    "logo": {
+                        "url": "https://example.invalid/logo.png"
+                    }
+                }]
+            }));
+        });
+
+        let mut args = curseforge_search_args("jei");
+        args.game_version = "1.20.1".to_string();
+        args.mod_loader = "Forge".to_string();
+        args.categories = vec!["423".to_string(), "5191".to_string()];
+        args.sort_by = "updated".to_string();
+        args.offset = 50;
+
+        let mods = search_mods_curseforge(args).await.unwrap();
+        search.assert();
+
+        assert_eq!(mods.len(), 1);
+        assert_eq!(mods[0].id, "238222");
+        assert_eq!(mods[0].name, "Just Enough Items");
+        assert_eq!(mods[0].slug, "jei");
+        assert_eq!(mods[0].source, ModSource::CurseForge);
+        assert_eq!(mods[0].mod_type, ModType::Mod);
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_CURSEFORGE_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn search_mods_curseforge_errors_on_http_error_status() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_CURSEFORGE_API_BASE", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/v1/mods/search");
+            then.status(500)
+                .header("content-type", "text/plain")
+                .body("search backend exploded");
+        });
+
+        search_mods_curseforge(curseforge_search_args("broken"))
+            .await
+            .unwrap_err();
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_CURSEFORGE_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn get_latest_mod_version_curseforge_sorts_files_by_date() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_CURSEFORGE_API_BASE", server.base_url());
+        }
+
+        let files = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/mods/77/files")
+                .header("x-api-key", env!("ETERNAL_API_TOKEN"))
+                .query_param("gameVersion", "1.20.1")
+                .query_param("modLoaderType", "1");
+            then.status(200).json_body(json!({
+                "data": [
+                    {
+                        "id": 1,
+                        "gameId": 432,
+                        "modId": 77,
+                        "isAvailable": true,
+                        "fileName": "old.jar",
+                        "hashes": [{ "value": "old", "algo": 1 }],
+                        "fileDate": "2024-01-01T00:00:00+00:00",
+                        "fileLength": 1,
+                        "downloadUrl": "https://example.invalid/old.jar"
+                    },
+                    {
+                        "id": 2,
+                        "gameId": 432,
+                        "modId": 77,
+                        "isAvailable": true,
+                        "fileName": "new.jar",
+                        "hashes": [{ "value": "new", "algo": 1 }],
+                        "fileDate": "2024-06-01T00:00:00+00:00",
+                        "fileLength": 2,
+                        "downloadUrl": "https://example.invalid/new.jar"
+                    }
+                ]
+            }));
+        });
+
+        let file = get_latest_mod_version_curseforge(
+            "77".to_string(),
+            "1.20.1".to_string(),
+            ModLoader::Forge,
+            ModType::Mod,
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        files.assert();
+        assert_eq!(file.id, 2);
+        assert_eq!(file.file_name, "new.jar");
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_CURSEFORGE_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn get_latest_mod_version_curseforge_uses_explicit_file_id() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_CURSEFORGE_API_BASE", server.base_url());
+        }
+
+        let file_lookup = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/mods/77/files/999")
+                .header("x-api-key", env!("ETERNAL_API_TOKEN"));
+            then.status(200).json_body(json!({
+                "data": {
+                    "id": 999,
+                    "gameId": 432,
+                    "modId": 77,
+                    "isAvailable": true,
+                    "fileName": "pinned.jar",
+                    "hashes": [{ "value": "pinned", "algo": 1 }],
+                    "fileDate": "2024-03-01T00:00:00+00:00",
+                    "fileLength": 3,
+                    "downloadUrl": "https://example.invalid/pinned.jar"
+                }
+            }));
+        });
+
+        let file = get_latest_mod_version_curseforge(
+            "77".to_string(),
+            "1.20.1".to_string(),
+            ModLoader::Forge,
+            ModType::Mod,
+            Some("999".to_string()),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        file_lookup.assert();
+        assert_eq!(file.id, 999);
+        assert_eq!(file.file_name, "pinned.jar");
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_CURSEFORGE_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn get_categories_curseforge_skips_class_rows_and_invalid_entries() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_CURSEFORGE_API_BASE", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/categories")
+                .header("x-api-key", env!("ETERNAL_API_TOKEN"))
+                .query_param("gameId", "432")
+                .query_param("classId", "6");
+            then.status(200).json_body(json!({
+                "data": [
+                    { "id": 6, "name": "Mods", "isClass": true },
+                    { "id": 423, "name": "Map and Information" },
+                    { "id": 0, "name": "Broken" },
+                    { "id": 5, "name": "" }
+                ]
+            }));
+        });
+
+        let categories = get_categories_curseforge(ModType::Mod).await.unwrap();
+
+        assert_eq!(categories.len(), 1);
+        assert_eq!(categories[0].id, "423");
+        assert_eq!(categories[0].name, "Map and Information");
+        assert_eq!(categories[0].header, "categories");
+        assert_eq!(categories[0].source, ModSource::CurseForge);
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_CURSEFORGE_API_BASE");
+        }
         clear_provider_http_cache().await;
     }
 }

--- a/src-tauri/crates/quadrant-core/src/mc_mod/curseforge_fingerprint.rs
+++ b/src-tauri/crates/quadrant-core/src/mc_mod/curseforge_fingerprint.rs
@@ -45,3 +45,63 @@ pub fn compute_normalized_length(buffer: &Buffer) -> u32 {
 pub fn is_whitespace_character(b: u8) -> bool {
     matches!(b, 9 | 10 | 13 | 32)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_whitespace_character_matches_curseforge_set() {
+        for b in [9, 10, 13, 32] {
+            assert!(is_whitespace_character(b));
+        }
+        for b in [0, 8, 11, 12, 14, 31, 33, b'a', 0xff] {
+            assert!(!is_whitespace_character(b));
+        }
+    }
+
+    #[test]
+    fn compute_normalized_length_ignores_whitespace() {
+        assert_eq!(compute_normalized_length(&Vec::new()), 0);
+        assert_eq!(compute_normalized_length(&vec![9, 10, 13, 32]), 0);
+        assert_eq!(
+            compute_normalized_length(&b"\t\nhello\r world\t\r\n ".to_vec()),
+            10
+        );
+        assert_eq!(
+            compute_normalized_length(&vec![
+                0x00, 0x01, 0xfe, 0xff, 0x7f, 0x80, 0x09, 0x0a, 0x0d, 0x20, 0x41
+            ]),
+            7
+        );
+    }
+
+    #[test]
+    fn compute_hash_golden_values() {
+        assert_eq!(compute_hash(&Vec::new()), 1540447798);
+        assert_eq!(compute_hash(&b"helloworld".to_vec()), 2824650221);
+        assert_eq!(
+            compute_hash(&vec![
+                0x00, 0x01, 0xfe, 0xff, 0x7f, 0x80, 0x09, 0x0a, 0x0d, 0x20, 0x41
+            ]),
+            2087903364
+        );
+    }
+
+    #[test]
+    fn compute_hash_strips_whitespace_bytes() {
+        assert_eq!(
+            compute_hash(&b"\t\nhello\r world\t\r\n ".to_vec()),
+            compute_hash(&b"helloworld".to_vec())
+        );
+        assert_eq!(
+            compute_hash(&vec![9, 10, 13, 32, 32, 13, 10, 9]),
+            compute_hash(&Vec::new())
+        );
+    }
+
+    #[test]
+    fn get_jar_contents_returns_empty_for_missing_file() {
+        assert!(get_jar_contents("/nonexistent/quadrant-test.jar").is_empty());
+    }
+}

--- a/src-tauri/crates/quadrant-core/src/mc_mod/mod.rs
+++ b/src-tauri/crates/quadrant-core/src/mc_mod/mod.rs
@@ -847,3 +847,134 @@ pub async fn identify_modpack(
     log::info!("Identified {} mod(s)", mods.len());
     Ok(mods)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mod_type_from_string_covers_aliases_and_fallback() {
+        let cases = [
+            ("mod", ModType::Mod),
+            ("Mod", ModType::Mod),
+            ("shader", ModType::ShaderPack),
+            ("shaderpack", ModType::ShaderPack),
+            ("ShaderPack", ModType::ShaderPack),
+            ("resourcepack", ModType::ResourcePack),
+            ("modpack", ModType::Modpack),
+            ("datapack", ModType::DataPack),
+            ("", ModType::Unknown),
+            ("plugin", ModType::Unknown),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(ModType::from(input.to_string()), expected, "{input:?}");
+        }
+    }
+
+    #[test]
+    fn mod_type_curseforge_class_ids_round_trip() {
+        let cases = [
+            (ModType::Mod, 6),
+            (ModType::ResourcePack, 12),
+            (ModType::ShaderPack, 6552),
+            (ModType::Modpack, 4471),
+            (ModType::DataPack, 6945),
+        ];
+        for (mod_type, class_id) in cases {
+            assert_eq!(mod_type.curseforge_id(), class_id as i32);
+            assert_eq!(ModType::from_curseforge_class(class_id), mod_type);
+        }
+        assert_eq!(ModType::Unknown.curseforge_id(), 999);
+        assert_eq!(ModType::from_curseforge_class(0), ModType::Unknown);
+        assert_eq!(ModType::from_curseforge_class(999), ModType::Unknown);
+    }
+
+    #[test]
+    fn mod_type_display_labels() {
+        assert_eq!(ModType::Mod.to_string(), "mod");
+        assert_eq!(ModType::ResourcePack.to_string(), "resourcepack");
+        assert_eq!(ModType::ShaderPack.to_string(), "shader");
+        assert_eq!(ModType::Modpack.to_string(), "modpack");
+        assert_eq!(ModType::DataPack.to_string(), "datapack");
+        assert_eq!(ModType::Unknown.to_string(), "unknown");
+    }
+
+    #[test]
+    fn get_mod_url_builds_curseforge_urls() {
+        let cases = [
+            (ModType::Mod, "https://curseforge.com/minecraft/mc-mods/jei"),
+            (
+                ModType::ResourcePack,
+                "https://curseforge.com/minecraft/texture-packs/jei",
+            ),
+            (
+                ModType::ShaderPack,
+                "https://curseforge.com/minecraft/customization/jei",
+            ),
+            (
+                ModType::Modpack,
+                "https://curseforge.com/minecraft/modpacks/jei",
+            ),
+            (
+                ModType::DataPack,
+                "https://curseforge.com/minecraft/data-packs/jei",
+            ),
+            (ModType::Unknown, "https://curseforge.com/minecraft//jei"),
+        ];
+        for (mod_type, expected) in cases {
+            assert_eq!(
+                get_mod_url("jei".to_string(), mod_type, ModSource::CurseForge),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn get_mod_url_builds_modrinth_urls() {
+        let cases = [
+            (ModType::Mod, "https://modrinth.com/mod/sodium"),
+            (
+                ModType::ResourcePack,
+                "https://modrinth.com/resourcepack/sodium",
+            ),
+            (ModType::ShaderPack, "https://modrinth.com/shader/sodium"),
+            (ModType::Modpack, "https://modrinth.com/modpack/sodium"),
+            (ModType::DataPack, "https://modrinth.com/datapack/sodium"),
+            (ModType::Unknown, "https://modrinth.com/unknown/sodium"),
+        ];
+        for (mod_type, expected) in cases {
+            assert_eq!(
+                get_mod_url("sodium".to_string(), mod_type, ModSource::Modrinth),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn get_mod_url_online_has_no_base() {
+        assert_eq!(
+            get_mod_url("thing".to_string(), ModType::Mod, ModSource::Online),
+            "//thing"
+        );
+    }
+
+    #[test]
+    fn get_user_url_builds_provider_profile_urls() {
+        assert_eq!(
+            get_user_url("dev".to_string(), ModSource::CurseForge),
+            "https://curseforge.com/members/dev"
+        );
+        assert_eq!(
+            get_user_url("dev".to_string(), ModSource::Modrinth),
+            "https://modrinth.com/user/dev"
+        );
+        assert_eq!(get_user_url("dev".to_string(), ModSource::Online), "/dev");
+    }
+
+    #[test]
+    fn get_user_agent_embeds_crate_version() {
+        let agent = get_user_agent();
+        assert!(agent.starts_with("mrquantumoff/quadrant/v"));
+        assert!(agent.contains(env!("CARGO_PKG_VERSION")));
+    }
+}

--- a/src-tauri/crates/quadrant-core/src/mc_mod/modrinth.rs
+++ b/src-tauri/crates/quadrant-core/src/mc_mod/modrinth.rs
@@ -232,10 +232,7 @@ pub async fn get_mod_modrinth(args: GetModArgs) -> Result<Mod> {
             .and_then(|version| version.as_str())
             .unwrap_or_default()
             .to_string(),
-        date_modified: res_json["updated"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string(),
+        date_modified: res_json["updated"].as_str().unwrap_or_default().to_string(),
         mod_type,
         source: ModSource::Modrinth,
         slug: res_json["slug"].as_str().unwrap_or_default().to_string(),
@@ -507,6 +504,20 @@ mod tests {
     use serde_json::json;
     use tempfile::tempdir;
 
+    fn modrinth_search_args(query: &str) -> SearchModsArgs {
+        SearchModsArgs {
+            query: query.to_string(),
+            mod_type: "mod".to_string(),
+            filter_on: false,
+            game_version: String::new(),
+            mod_loader: String::new(),
+            categories: Vec::new(),
+            open_source: false,
+            sort_by: "relevance".to_string(),
+            offset: 0,
+        }
+    }
+
     fn modrinth_get_mod_args(id: &str) -> GetModArgs {
         GetModArgs {
             id: id.to_string(),
@@ -629,6 +640,264 @@ mod tests {
         assert_eq!(first.len(), 1);
         assert_eq!(second.len(), 1);
         version_lookup.assert_calls(1);
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_MODRINTH_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn search_mods_modrinth_serializes_query_and_facets() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_MODRINTH_API_BASE", server.base_url());
+        }
+
+        let search = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v2/search")
+                .query_param("query", "sodium")
+                .query_param("limit", "100")
+                .query_param("offset", "20")
+                .query_param("index", "downloads")
+                .query_param(
+                    "facets",
+                    concat!(
+                        "[[\"project_type:mod\"],[\"versions:1.20.1\"],",
+                        "[\"categories:fabric\"],",
+                        "[\"categories:optimization\",\"categories:utility\"],",
+                        "[\"open_source:true\"]]"
+                    ),
+                );
+            then.status(200).json_body(json!({
+                "hits": [{
+                    "title": "Sodium",
+                    "project_id": "AANobbMI",
+                    "downloads": 1000,
+                    "date_modified": "2024-01-01T00:00:00Z",
+                    "slug": "sodium",
+                    "description": "fast",
+                    "license": "LGPL-3.0",
+                    "icon_url": "https://example.invalid/icon.png",
+                    "gallery": ["https://example.invalid/screenshot.png"]
+                }]
+            }));
+        });
+
+        let mut args = modrinth_search_args("sodium");
+        args.game_version = "1.20.1".to_string();
+        args.mod_loader = "Fabric".to_string();
+        args.categories = vec!["optimization".to_string(), "utility".to_string()];
+        args.open_source = true;
+        args.sort_by = "downloads".to_string();
+        args.offset = 20;
+
+        let mods = search_mods_modrinth(args).await.unwrap();
+        search.assert();
+
+        assert_eq!(mods.len(), 1);
+        assert_eq!(mods[0].name, "Sodium");
+        assert_eq!(mods[0].id, "AANobbMI");
+        assert_eq!(mods[0].slug, "sodium");
+        assert_eq!(mods[0].source, ModSource::Modrinth);
+        assert_eq!(mods[0].download_count, 1000);
+        assert_eq!(
+            mods[0].thumbnail_urls,
+            vec!["https://example.invalid/screenshot.png".to_string()]
+        );
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_MODRINTH_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn search_mods_modrinth_errors_on_http_error_status() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_MODRINTH_API_BASE", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/v2/search");
+            then.status(500).body("search backend exploded");
+        });
+
+        let error = search_mods_modrinth(modrinth_search_args("broken"))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("500"));
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_MODRINTH_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn search_mods_modrinth_errors_on_malformed_json() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_MODRINTH_API_BASE", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/v2/search");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("{not-json");
+        });
+
+        search_mods_modrinth(modrinth_search_args("malformed"))
+            .await
+            .unwrap_err();
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_MODRINTH_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn get_latest_mod_version_modrinth_prefers_newest_primary_file() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_MODRINTH_API_BASE", server.base_url());
+        }
+
+        let versions = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v2/project/demo-mod/version")
+                .query_param("game_versions", "[\"1.20.1\"]")
+                .query_param("loaders", "[\"fabric\"]");
+            then.status(200).json_body(json!([
+                {
+                    "date_published": "2024-01-01T00:00:00Z",
+                    "files": [{
+                        "hashes": { "sha512": "unused", "sha1": "old" },
+                        "url": "https://example.invalid/old.jar",
+                        "filename": "old.jar",
+                        "primary": true,
+                        "size": 1
+                    }]
+                },
+                {
+                    "date_published": "2024-06-01T00:00:00Z",
+                    "files": [
+                        {
+                            "hashes": { "sha512": "unused", "sha1": "extra" },
+                            "url": "https://example.invalid/extra.jar",
+                            "filename": "extra.jar",
+                            "primary": false,
+                            "size": 2
+                        },
+                        {
+                            "hashes": { "sha512": "unused", "sha1": "new" },
+                            "url": "https://example.invalid/new.jar",
+                            "filename": "new.jar",
+                            "primary": true,
+                            "size": 3
+                        }
+                    ]
+                }
+            ]));
+        });
+
+        let file = get_latest_mod_version_modrinth(
+            "demo-mod".to_string(),
+            "1.20.1".to_string(),
+            ModLoader::Fabric,
+            ModType::Mod,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        versions.assert();
+        assert_eq!(file.filename, "new.jar");
+        assert_eq!(file.hashes.sha1, "new");
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_MODRINTH_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn get_latest_mod_version_modrinth_errors_when_no_versions() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_MODRINTH_API_BASE", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/v2/project/empty-mod/version");
+            then.status(200).json_body(json!([]));
+        });
+
+        let error = get_latest_mod_version_modrinth(
+            "empty-mod".to_string(),
+            "1.20.1".to_string(),
+            ModLoader::Fabric,
+            ModType::Mod,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("noVersion"));
+
+        unsafe {
+            std::env::remove_var("QUADRANT_TEST_MODRINTH_API_BASE");
+        }
+        clear_provider_http_cache().await;
+    }
+
+    #[tokio::test]
+    async fn get_categories_modrinth_maps_and_filters_tags() {
+        let _guard = PROVIDER_HTTP_TEST_MUTEX.lock().await;
+        clear_provider_http_cache().await;
+
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("QUADRANT_TEST_MODRINTH_API_BASE", server.base_url());
+        }
+
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/v2/tag/category");
+            then.status(200).json_body(json!([
+                { "name": "game-mechanics", "project_type": "mod", "header": "categories" },
+                { "name": "optimization", "project_type": "mod" },
+                { "name": "32x", "project_type": "resourcepack", "header": "resolutions" },
+                { "name": "", "project_type": "mod", "header": "categories" }
+            ]));
+        });
+
+        let categories = get_categories_modrinth(ModType::Mod).await.unwrap();
+
+        assert_eq!(categories.len(), 2);
+        assert_eq!(categories[0].id, "game-mechanics");
+        assert_eq!(categories[0].name, "Game Mechanics");
+        assert_eq!(categories[0].header, "categories");
+        assert_eq!(categories[0].source, ModSource::Modrinth);
+        assert_eq!(categories[1].id, "optimization");
+        assert_eq!(categories[1].name, "Optimization");
+        assert_eq!(categories[1].header, "categories");
 
         unsafe {
             std::env::remove_var("QUADRANT_TEST_MODRINTH_API_BASE");

--- a/src-tauri/crates/quadrant-core/src/models.rs
+++ b/src-tauri/crates/quadrant-core/src/models.rs
@@ -352,3 +352,333 @@ pub struct Article {
 pub fn modpack_path(mc_folder: &Path, modpack_name: &str) -> PathBuf {
     mc_folder.join("modpacks").join(modpack_name)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const ALL_LOADERS: [ModLoader; 14] = [
+        ModLoader::Forge,
+        ModLoader::Fabric,
+        ModLoader::NeoForge,
+        ModLoader::Babric,
+        ModLoader::BtaBabric,
+        ModLoader::JavaAgent,
+        ModLoader::LegacyFabric,
+        ModLoader::LiteLoader,
+        ModLoader::RisugamisModLoader,
+        ModLoader::NilLoader,
+        ModLoader::Ornithe,
+        ModLoader::Quilt,
+        ModLoader::Rift,
+        ModLoader::Unknown,
+    ];
+
+    #[test]
+    fn mod_loader_from_string_covers_all_variants_and_aliases() {
+        let cases = [
+            ("forge", ModLoader::Forge),
+            ("Forge", ModLoader::Forge),
+            ("  fabric  ", ModLoader::Fabric),
+            ("neoforge", ModLoader::NeoForge),
+            ("babric", ModLoader::Babric),
+            ("BTA (Babric)", ModLoader::BtaBabric),
+            ("bta-babric", ModLoader::BtaBabric),
+            ("bta babric", ModLoader::BtaBabric),
+            ("Java Agent", ModLoader::JavaAgent),
+            ("java-agent", ModLoader::JavaAgent),
+            ("Legacy Fabric", ModLoader::LegacyFabric),
+            ("legacy-fabric", ModLoader::LegacyFabric),
+            ("LiteLoader", ModLoader::LiteLoader),
+            ("lite loader", ModLoader::LiteLoader),
+            ("lite-loader", ModLoader::LiteLoader),
+            ("Risugami's ModLoader", ModLoader::RisugamisModLoader),
+            ("risugamis modloader", ModLoader::RisugamisModLoader),
+            ("risugami modloader", ModLoader::RisugamisModLoader),
+            ("modloader", ModLoader::RisugamisModLoader),
+            ("NilLoader", ModLoader::NilLoader),
+            ("nil loader", ModLoader::NilLoader),
+            ("nil-loader", ModLoader::NilLoader),
+            ("ornithe", ModLoader::Ornithe),
+            ("quilt", ModLoader::Quilt),
+            ("rift", ModLoader::Rift),
+            ("Unknown", ModLoader::Unknown),
+            ("", ModLoader::Unknown),
+            ("paper", ModLoader::Unknown),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(ModLoader::from(input.to_string()), expected, "{input:?}");
+        }
+    }
+
+    #[test]
+    fn mod_loader_display_round_trips_through_from() {
+        for loader in ALL_LOADERS {
+            assert_eq!(ModLoader::from(loader.to_string()), loader);
+        }
+    }
+
+    #[test]
+    fn mod_loader_modrinth_slugs() {
+        let cases = [
+            (ModLoader::Forge, Some("forge")),
+            (ModLoader::Fabric, Some("fabric")),
+            (ModLoader::NeoForge, Some("neoforge")),
+            (ModLoader::Babric, Some("babric")),
+            (ModLoader::BtaBabric, Some("bta-babric")),
+            (ModLoader::JavaAgent, Some("java-agent")),
+            (ModLoader::LegacyFabric, Some("legacy-fabric")),
+            (ModLoader::LiteLoader, Some("liteloader")),
+            (ModLoader::RisugamisModLoader, Some("modloader")),
+            (ModLoader::NilLoader, Some("nilloader")),
+            (ModLoader::Ornithe, Some("ornithe")),
+            (ModLoader::Quilt, Some("quilt")),
+            (ModLoader::Rift, Some("rift")),
+            (ModLoader::Unknown, None),
+        ];
+        for (loader, expected) in cases {
+            assert_eq!(loader.modrinth_slug(), expected, "{loader}");
+        }
+    }
+
+    #[test]
+    fn mod_loader_curseforge_ids() {
+        assert_eq!(ModLoader::Forge.curseforge_id(), Some(1));
+        assert_eq!(ModLoader::LiteLoader.curseforge_id(), Some(3));
+        assert_eq!(ModLoader::Fabric.curseforge_id(), Some(4));
+        assert_eq!(ModLoader::Quilt.curseforge_id(), Some(5));
+        assert_eq!(ModLoader::NeoForge.curseforge_id(), Some(6));
+        for loader in [
+            ModLoader::Babric,
+            ModLoader::BtaBabric,
+            ModLoader::JavaAgent,
+            ModLoader::LegacyFabric,
+            ModLoader::RisugamisModLoader,
+            ModLoader::NilLoader,
+            ModLoader::Ornithe,
+            ModLoader::Rift,
+            ModLoader::Unknown,
+        ] {
+            assert_eq!(loader.curseforge_id(), None, "{loader}");
+        }
+        assert_eq!(ModLoader::Forge.to_curseforge_id(), 1);
+        assert_eq!(ModLoader::Unknown.to_curseforge_id(), 0);
+    }
+
+    #[test]
+    fn mod_loader_serde_uses_display_labels() {
+        for loader in ALL_LOADERS {
+            let serialized = serde_json::to_value(loader).unwrap();
+            assert_eq!(serialized, json!(loader.to_string()));
+            let round_tripped: ModLoader = serde_json::from_value(serialized).unwrap();
+            assert_eq!(round_tripped, loader);
+        }
+    }
+
+    #[test]
+    fn mod_source_serde_uses_dart_style_names() {
+        assert_eq!(
+            serde_json::to_value(ModSource::CurseForge).unwrap(),
+            json!("ModSource.curseForge")
+        );
+        assert_eq!(
+            serde_json::to_value(ModSource::Modrinth).unwrap(),
+            json!("ModSource.modRinth")
+        );
+        assert_eq!(
+            serde_json::to_value(ModSource::Online).unwrap(),
+            json!("ModSource.online")
+        );
+        assert_eq!(
+            serde_json::from_value::<ModSource>(json!("ModSource.curseForge")).unwrap(),
+            ModSource::CurseForge
+        );
+        assert!(serde_json::from_value::<ModSource>(json!("curseForge")).is_err());
+    }
+
+    #[test]
+    fn installed_mod_serializes_camel_case_fields() {
+        let mod_ = InstalledMod {
+            name: "Sodium".to_string(),
+            id: "AANobbMI".to_string(),
+            download_count: 7,
+            version: "0.5.8".to_string(),
+            mod_type: "Mod".to_string(),
+            source: ModSource::Modrinth,
+            slug: "sodium".to_string(),
+            thumbnail_urls: vec!["https://example.invalid/thumb.png".to_string()],
+            description: "desc".to_string(),
+            license: "LGPL-3.0".to_string(),
+            mod_icon_url: "https://example.invalid/icon.png".to_string(),
+            download_url: "https://cdn.modrinth.com/sodium.jar".to_string(),
+        };
+        let value = serde_json::to_value(&mod_).unwrap();
+        assert_eq!(value["downloadCount"], json!(7));
+        assert_eq!(value["modType"], json!("Mod"));
+        assert_eq!(
+            value["thumbnailUrls"],
+            json!(["https://example.invalid/thumb.png"])
+        );
+        assert_eq!(
+            value["modIconUrl"],
+            json!("https://example.invalid/icon.png")
+        );
+        assert_eq!(
+            value["downloadUrl"],
+            json!("https://cdn.modrinth.com/sodium.jar")
+        );
+        assert_eq!(value["source"], json!("ModSource.modRinth"));
+
+        let round_tripped: InstalledMod = serde_json::from_value(value).unwrap();
+        assert_eq!(round_tripped.download_count, 7);
+        assert_eq!(round_tripped.mod_icon_url, mod_.mod_icon_url);
+    }
+
+    #[test]
+    fn installed_mod_deserializes_with_minimal_fields() {
+        let mod_: InstalledMod = serde_json::from_value(json!({
+            "id": "abc",
+            "source": "ModSource.curseForge",
+            "downloadUrl": "https://forgecdn.net/mod.jar"
+        }))
+        .unwrap();
+        assert_eq!(mod_.id, "abc");
+        assert_eq!(mod_.source, ModSource::CurseForge);
+        assert_eq!(mod_.name, "");
+        assert_eq!(mod_.download_count, 0);
+        assert!(mod_.thumbnail_urls.is_empty());
+    }
+
+    #[test]
+    fn installed_modpack_serde_pins_field_names_and_defaults() {
+        let modpack = InstalledModpack {
+            mod_config_version: "2".to_string(),
+            quadrant_version: "26.7.6".to_string(),
+            name: "alpha".to_string(),
+            version: "1.20.1".to_string(),
+            mod_loader: ModLoader::BtaBabric,
+            mods: Vec::new(),
+        };
+        let value = serde_json::to_value(&modpack).unwrap();
+        assert_eq!(value["modConfigVersion"], json!("2"));
+        assert_eq!(value["quadrantVersion"], json!("26.7.6"));
+        assert_eq!(value["modLoader"], json!("BTA (Babric)"));
+
+        let legacy: InstalledModpack = serde_json::from_value(json!({
+            "name": "legacy",
+            "version": "1.12.2",
+            "modLoader": "Forge",
+            "mods": []
+        }))
+        .unwrap();
+        assert_eq!(legacy.mod_config_version, "1");
+        assert_eq!(legacy.quadrant_version, "");
+    }
+
+    #[test]
+    fn local_modpack_serde_pins_field_names() {
+        let modpack: LocalModpack = serde_json::from_value(json!({
+            "name": "alpha",
+            "version": "1.20.1",
+            "modLoader": "Fabric",
+            "mods": [],
+            "unknownMods": true,
+            "isApplied": false,
+            "lastSynced": 42000,
+            "modpackId": "pack-1"
+        }))
+        .unwrap();
+        assert!(modpack.unknown_mods);
+        assert!(!modpack.is_applied);
+        assert_eq!(modpack.last_synced, 42_000);
+        assert_eq!(modpack.modpack_id.as_deref(), Some("pack-1"));
+
+        let value = serde_json::to_value(&modpack).unwrap();
+        assert_eq!(value["unknownMods"], json!(true));
+        assert_eq!(value["isApplied"], json!(false));
+        assert_eq!(value["lastSynced"], json!(42_000));
+        assert_eq!(value["modpackId"], json!("pack-1"));
+    }
+
+    #[test]
+    fn local_modpack_last_synced_accepts_integral_numbers_only() {
+        let base = |last_synced: Value| {
+            json!({
+                "name": "alpha",
+                "version": "1.20.1",
+                "modLoader": "Fabric",
+                "mods": [],
+                "unknownMods": false,
+                "isApplied": false,
+                "lastSynced": last_synced,
+                "modpackId": null
+            })
+        };
+
+        let from_int: LocalModpack = serde_json::from_value(base(json!(1234))).unwrap();
+        assert_eq!(from_int.last_synced, 1234);
+        let from_float: LocalModpack = serde_json::from_value(base(json!(1234.0))).unwrap();
+        assert_eq!(from_float.last_synced, 1234);
+        let from_negative: LocalModpack = serde_json::from_value(base(json!(-5.0))).unwrap();
+        assert_eq!(from_negative.last_synced, -5);
+        let from_u64: LocalModpack =
+            serde_json::from_value(base(json!(u64::from(u32::MAX)))).unwrap();
+        assert_eq!(from_u64.last_synced, i64::from(u32::MAX));
+
+        assert!(serde_json::from_value::<LocalModpack>(base(json!(12.5))).is_err());
+        assert!(serde_json::from_value::<LocalModpack>(base(json!(u64::MAX))).is_err());
+        assert!(serde_json::from_value::<LocalModpack>(base(json!("42"))).is_err());
+        assert!(serde_json::from_value::<LocalModpack>(base(json!(null))).is_err());
+    }
+
+    #[test]
+    fn installed_modpack_from_local_modpack_stamps_versions() {
+        let local = LocalModpack {
+            name: "alpha".to_string(),
+            version: "1.20.1".to_string(),
+            mod_loader: ModLoader::Quilt,
+            mods: vec![InstalledMod::minimal(
+                "mod-1".to_string(),
+                ModSource::Online,
+                "https://example.invalid/mod.jar".to_string(),
+            )],
+            unknown_mods: true,
+            is_applied: true,
+            last_synced: 99,
+            modpack_id: Some("pack-1".to_string()),
+        };
+        let installed = InstalledModpack::from(local);
+        assert_eq!(installed.mod_config_version, "2");
+        assert_eq!(installed.quadrant_version, quadrant_version());
+        assert_eq!(installed.name, "alpha");
+        assert_eq!(installed.version, "1.20.1");
+        assert_eq!(installed.mod_loader, ModLoader::Quilt);
+        assert_eq!(installed.mods.len(), 1);
+    }
+
+    #[test]
+    fn local_modpack_from_installed_tuple_defaults_extras() {
+        let installed = InstalledModpack {
+            mod_config_version: "2".to_string(),
+            quadrant_version: "x".to_string(),
+            name: "alpha".to_string(),
+            version: "1.20.1".to_string(),
+            mod_loader: ModLoader::Forge,
+            mods: Vec::new(),
+        };
+        let local = LocalModpack::from((installed, true, 7));
+        assert!(local.is_applied);
+        assert_eq!(local.last_synced, 7);
+        assert_eq!(local.modpack_id, None);
+        assert!(!local.unknown_mods);
+    }
+
+    #[test]
+    fn modpack_path_appends_modpacks_folder() {
+        assert_eq!(
+            modpack_path(Path::new("/mc"), "alpha"),
+            PathBuf::from("/mc/modpacks/alpha")
+        );
+    }
+}

--- a/src-tauri/crates/quadrant-core/src/modpacks.rs
+++ b/src-tauri/crates/quadrant-core/src/modpacks.rs
@@ -1038,4 +1038,185 @@ mod tests {
             modpack_path(&mc_folder, "beta")
         );
     }
+
+    #[test]
+    fn validate_modpack_name_accepts_single_normal_components() {
+        for name in ["alpha", "My Pack 2", "пак", "パック", "pack.v2"] {
+            assert!(validate_modpack_name(name).is_ok(), "{name:?}");
+        }
+    }
+
+    #[test]
+    fn validate_modpack_name_rejects_traversal_and_multi_component_paths() {
+        for name in [
+            "",
+            ".",
+            "..",
+            "a/b",
+            "/etc",
+            "../escape",
+            "a/..",
+            "a/./b",
+            "modpacks/../../x",
+        ] {
+            assert!(validate_modpack_name(name).is_err(), "{name:?}");
+        }
+    }
+
+    #[test]
+    fn safe_download_file_name_extracts_and_decodes_names() {
+        assert_eq!(
+            safe_download_file_name(
+                "https://cdn.modrinth.com/data/AANobbMI/versions/mod.jar",
+                &ModSource::Modrinth,
+            )
+            .unwrap(),
+            "mod.jar"
+        );
+        assert_eq!(
+            safe_download_file_name(
+                "https://cdn.modrinth.com/data/my%20mod%20v1.2.jar",
+                &ModSource::Modrinth,
+            )
+            .unwrap(),
+            "my mod v1.2.jar"
+        );
+        assert_eq!(
+            safe_download_file_name(
+                "https://mediafilez.forgecdn.net/files/1/2/jei.jar",
+                &ModSource::CurseForge,
+            )
+            .unwrap(),
+            "jei.jar"
+        );
+        assert_eq!(
+            safe_download_file_name("https://example.com/files/пак.jar", &ModSource::Online)
+                .unwrap(),
+            "пак.jar"
+        );
+        assert_eq!(
+            safe_download_file_name("https://cdn.modrinth.com/mod.jar/", &ModSource::Modrinth)
+                .unwrap(),
+            "mod.jar"
+        );
+    }
+
+    #[test]
+    fn safe_download_file_name_restricts_schemes() {
+        assert!(
+            safe_download_file_name("http://127.0.0.1:8080/mod.jar", &ModSource::Modrinth).is_ok()
+        );
+        assert!(
+            safe_download_file_name("http://localhost:8080/mod.jar", &ModSource::Modrinth).is_err()
+        );
+        assert!(safe_download_file_name("http://example.com/mod.jar", &ModSource::Online).is_err());
+        assert!(
+            safe_download_file_name("ftp://cdn.modrinth.com/mod.jar", &ModSource::Modrinth)
+                .is_err()
+        );
+        assert!(safe_download_file_name("file:///etc/passwd", &ModSource::Online).is_err());
+    }
+
+    #[test]
+    fn safe_download_file_name_rejects_traversal_and_empty_names() {
+        for url in [
+            "https://cdn.modrinth.com/..%2Fescape.jar",
+            "https://cdn.modrinth.com/%2E%2E",
+            "https://cdn.modrinth.com/a%2Fb.jar",
+            "https://cdn.modrinth.com/%2Fetc%2Fpasswd",
+            "https://cdn.modrinth.com",
+            "https://cdn.modrinth.com/",
+            "not a url",
+        ] {
+            assert!(
+                safe_download_file_name(url, &ModSource::Modrinth).is_err(),
+                "{url}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn modpack_operations_reject_missing_targets_and_duplicates() {
+        let (_dir, mc_folder) = setup_mc_folder();
+        let existing = get_modpacks(&mc_folder, false).await.unwrap();
+
+        assert!(delete_modpack(&mc_folder, &existing, "ghost").is_err());
+        assert!(apply_modpack(&mc_folder, "ghost").is_err());
+        assert!(update_modpack(&mc_folder, &existing, "ghost", None, None, None).is_err());
+        assert!(delete_mod(&mc_folder, &existing, "ghost", "mod-1").is_err());
+
+        create_modpack(&mc_folder, &existing, "alpha", "1.20.1", ModLoader::Fabric).unwrap();
+        let listed = get_modpacks(&mc_folder, false).await.unwrap();
+        assert!(create_modpack(&mc_folder, &listed, "alpha", "1.20.1", ModLoader::Fabric).is_err());
+
+        let mod_ = online_mod("mod-1", "https://example.invalid/mod.jar".to_string());
+        register_mod(&mc_folder, &listed, mod_.clone(), "alpha")
+            .await
+            .unwrap();
+        let listed = get_modpacks(&mc_folder, false).await.unwrap();
+        assert!(
+            register_mod(&mc_folder, &listed, mod_, "alpha")
+                .await
+                .is_err()
+        );
+        assert!(delete_mod(&mc_folder, &listed, "alpha", "other-mod").is_err());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn apply_modpack_backs_up_real_mods_directory() {
+        let (_dir, mc_folder) = setup_mc_folder();
+        std::fs::create_dir_all(modpack_path(&mc_folder, "alpha")).unwrap();
+        std::fs::create_dir_all(mc_folder.join("mods")).unwrap();
+        std::fs::write(mc_folder.join("mods").join("loose.jar"), "jar").unwrap();
+
+        apply_modpack(&mc_folder, "alpha").unwrap();
+
+        assert!(mc_folder.join("mods").is_symlink());
+        let backup = std::fs::read_dir(mc_folder.join("modpacks"))
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .find(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("mods-backup-")
+            })
+            .expect("backup folder should exist");
+        assert!(backup.path().join("loose.jar").exists());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn apply_modpack_switches_between_applied_modpacks() {
+        let (_dir, mc_folder) = setup_mc_folder();
+        std::fs::create_dir_all(modpack_path(&mc_folder, "alpha")).unwrap();
+        std::fs::create_dir_all(modpack_path(&mc_folder, "beta")).unwrap();
+
+        apply_modpack(&mc_folder, "alpha").unwrap();
+        apply_modpack(&mc_folder, "beta").unwrap();
+
+        let mods_path = mc_folder.join("mods");
+        assert_eq!(
+            mods_path.read_link().unwrap(),
+            modpack_path(&mc_folder, "beta")
+        );
+        // Switching must not delete the previously applied modpack's contents.
+        assert!(modpack_path(&mc_folder, "alpha").exists());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn delete_applied_modpack_removes_mods_link() {
+        let (_dir, mc_folder) = setup_mc_folder();
+        let existing = get_modpacks(&mc_folder, false).await.unwrap();
+        create_modpack(&mc_folder, &existing, "alpha", "1.20.1", ModLoader::Fabric).unwrap();
+        apply_modpack(&mc_folder, "alpha").unwrap();
+        let listed = get_modpacks(&mc_folder, false).await.unwrap();
+        assert!(listed[0].is_applied);
+
+        delete_modpack(&mc_folder, &listed, "alpha").unwrap();
+        assert!(!mc_folder.join("mods").is_symlink());
+        assert!(!modpack_path(&mc_folder, "alpha").exists());
+    }
 }

--- a/src-tauri/crates/quadrant-core/src/rss.rs
+++ b/src-tauri/crates/quadrant-core/src/rss.rs
@@ -14,7 +14,15 @@ pub async fn get_news() -> Result<Vec<Article>> {
         .bytes()
         .await
         .map_err(|error| anyhow!(error))?;
-    let rss = rss::Channel::read_from(&content[..]).map_err(|error| anyhow!(error))?;
+    let articles = parse_feed(&content, new_qualifier)?;
+    log::info!("Fetched {} article(s) from RSS feed", articles.len());
+    Ok(articles)
+}
+
+/// Converts raw RSS bytes into articles; items published after
+/// `new_qualifier` are marked as new.
+fn parse_feed(content: &[u8], new_qualifier: DateTime<Utc>) -> Result<Vec<Article>> {
+    let rss = rss::Channel::read_from(content).map_err(|error| anyhow!(error))?;
 
     let mut articles = Vec::new();
     for item in rss.items {
@@ -41,6 +49,65 @@ pub async fn get_news() -> Result<Vec<Article>> {
             guid,
         });
     }
-    log::info!("Fetched {} article(s) from RSS feed", articles.len());
     Ok(articles)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_feed;
+    use chrono::{DateTime, Utc};
+
+    fn feed(items: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>Blog</title><link>https://example.com</link><description>d</description>{items}</channel></rss>"#
+        )
+    }
+
+    fn qualifier() -> DateTime<Utc> {
+        "2026-03-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    }
+
+    #[test]
+    fn parse_feed_marks_recent_articles_as_new() {
+        let xml = feed(
+            r#"<item><title>Fresh</title><link>https://example.com/fresh</link><description>a</description><pubDate>Mon, 02 Mar 2026 12:00:00 GMT</pubDate><guid>g-fresh</guid></item>
+<item><title>Old</title><link>https://example.com/old</link><description>b</description><pubDate>Sun, 01 Feb 2026 12:00:00 GMT</pubDate><guid>g-old</guid></item>"#,
+        );
+
+        let articles = parse_feed(xml.as_bytes(), qualifier()).unwrap();
+        assert_eq!(articles.len(), 2);
+        assert!(articles[0].new);
+        assert_eq!(articles[0].title, "Fresh");
+        assert_eq!(articles[0].guid, "g-fresh");
+        assert!(!articles[1].new);
+    }
+
+    #[test]
+    fn parse_feed_skips_items_without_a_valid_date() {
+        let xml = feed(
+            r#"<item><title>No date</title><link>https://example.com/x</link></item>
+<item><title>Bad date</title><pubDate>not a date</pubDate></item>
+<item><title>Ok</title><link>https://example.com/ok</link><pubDate>Mon, 02 Mar 2026 12:00:00 GMT</pubDate></item>"#,
+        );
+
+        let articles = parse_feed(xml.as_bytes(), qualifier()).unwrap();
+        assert_eq!(articles.len(), 1);
+        assert_eq!(articles[0].title, "Ok");
+    }
+
+    #[test]
+    fn parse_feed_falls_back_to_link_for_missing_guid() {
+        let xml = feed(
+            r#"<item><title>t</title><link>https://example.com/only-link</link><pubDate>Mon, 02 Mar 2026 12:00:00 GMT</pubDate></item>"#,
+        );
+
+        let articles = parse_feed(xml.as_bytes(), qualifier()).unwrap();
+        assert_eq!(articles[0].guid, "https://example.com/only-link");
+    }
+
+    #[test]
+    fn parse_feed_rejects_malformed_xml() {
+        assert!(parse_feed(b"this is not xml", qualifier()).is_err());
+    }
 }

--- a/src-tauri/crates/quadrant-host/src/lib.rs
+++ b/src-tauri/crates/quadrant-host/src/lib.rs
@@ -2262,12 +2262,16 @@ struct CodeArgs {
 #[cfg(test)]
 mod tests {
     use super::{
-        HostEventEnvelope, JsonFileStore, Notification, NotificationCursor,
+        HostEventBridge, HostEventEnvelope, JsonFileStore, Notification, NotificationCursor,
         NotificationRuntimeState, QuadrantHost, QuadrantHostOptions,
         merge_notifications_and_collect_updates,
     };
-    use quadrant_core::{account::KEYRING_SERVICE, ports::SettingsStore};
-    use serde_json::Value;
+    use quadrant_core::{
+        account::KEYRING_SERVICE,
+        events::{BackendEvent, ModProgressPayload},
+        ports::{EventSink, SettingsStore},
+    };
+    use serde_json::{Value, json};
     use std::path::PathBuf;
     use tempfile::tempdir;
 
@@ -2393,5 +2397,76 @@ mod tests {
         let envelope: HostEventEnvelope = receiver.recv().await.unwrap();
         assert_eq!(envelope.event, "refreshSyncedModpacks");
         assert_eq!(envelope.payload, Value::String("modpack-1".to_string()));
+    }
+
+    #[test]
+    fn json_store_entries_and_deletes_round_trip_across_instances() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("config.json");
+
+        let store = JsonFileStore::new(path.clone()).unwrap();
+        store.set_string("mcFolder", "/tmp/mc").unwrap();
+        store.set_i64("lastPage", 3).unwrap();
+        store.set_bool("modrinth", true).unwrap();
+
+        let reloaded = JsonFileStore::new(path.clone()).unwrap();
+        let entries = reloaded.entries().unwrap();
+        assert_eq!(entries.len(), 3);
+        assert_eq!(
+            reloaded.get_string("mcFolder").unwrap().as_deref(),
+            Some("/tmp/mc")
+        );
+        assert_eq!(reloaded.get_i64("lastPage").unwrap(), Some(3));
+        assert_eq!(reloaded.get_bool("modrinth").unwrap(), Some(true));
+
+        reloaded.delete_key("lastPage").unwrap();
+
+        let after_delete = JsonFileStore::new(path).unwrap();
+        assert_eq!(after_delete.get_i64("lastPage").unwrap(), None);
+        assert_eq!(after_delete.entries().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn event_bridge_broadcasts_published_backend_events() {
+        let bridge = HostEventBridge::new();
+        let mut receiver = bridge.subscribe();
+
+        bridge
+            .publish(BackendEvent::ModDownloadProgress(ModProgressPayload {
+                mod_id: "mod-1".to_string(),
+                progress: 50,
+            }))
+            .unwrap();
+        bridge.publish(BackendEvent::RecheckAccountToken).unwrap();
+
+        let envelope = receiver.recv().await.unwrap();
+        assert_eq!(envelope.event, "modDownloadProgress");
+        assert_eq!(
+            envelope.payload,
+            json!({ "modId": "mod-1", "progress": 50 })
+        );
+
+        let envelope = receiver.recv().await.unwrap();
+        assert_eq!(envelope.event, "recheckAccountToken");
+        assert_eq!(envelope.payload, Value::Null);
+    }
+
+    #[test]
+    fn host_new_materializes_defaults_and_mc_folder() {
+        let temp_dir = tempdir().unwrap();
+        let mc_folder = temp_dir.path().join("mc");
+        let mut options =
+            QuadrantHostOptions::new(temp_dir.path().to_path_buf(), "client", "secret", "api-key");
+        options.mc_folder = Some(mc_folder.clone());
+        let host = QuadrantHost::new(options).unwrap();
+
+        assert_eq!(
+            host.get_config_value("curseforge").unwrap(),
+            Some(Value::Bool(true))
+        );
+        assert_eq!(
+            host.get_config_value("mcFolder").unwrap(),
+            Some(Value::String(mc_folder.to_string_lossy().to_string()))
+        );
     }
 }

--- a/src-tauri/src/mc_mod/mod.rs
+++ b/src-tauri/src/mc_mod/mod.rs
@@ -2,8 +2,8 @@ use quadrant_host::QuadrantHost;
 use tauri::{AppHandle, Manager};
 
 pub use quadrant_core::mc_mod::{
-    GetModArgs, GlobalSearchModsArgs, IdentifiedMod, MinecraftVersion, Mod, ModType, SearchCategory,
-    SearchModsArgs, UniversalModFile, get_mod_url, get_user_agent,
+    GetModArgs, GlobalSearchModsArgs, IdentifiedMod, MinecraftVersion, Mod, ModType,
+    SearchCategory, SearchModsArgs, UniversalModFile, get_mod_url, get_user_agent,
 };
 pub use quadrant_core::models::{InstalledMod, ModSource};
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import {
   ContentContext,
   type IContentContext,
   ModLoader,
-  ModSource,
   ModType,
   type Page,
   type SnackbarHistoryItem,
@@ -45,43 +44,13 @@ import {
   UI_SCALE_KEY,
   UI_SCALE_STEP,
 } from "./uiScale";
+import { resolveDeepLink } from "./deepLinks";
+import { appendSnackbarHistory } from "./snackbar";
 
 interface PageWithScroll {
   scrollPositionX: number;
   scrollPositionY: number;
   page: Page;
-}
-
-function getQuadrantPathParts(url: URL): string[] {
-  return url.pathname.split("/").filter((part) => part.trim().length > 0);
-}
-
-function getQuadrantAction(url: URL): string {
-  const pathAction = getQuadrantPathParts(url)[0];
-  return (url.host || pathAction || "").toLowerCase();
-}
-
-function getQuadrantPathValue(url: URL): string | undefined {
-  const pathParts = getQuadrantPathParts(url);
-  return url.host ? pathParts[0] : pathParts[1];
-}
-
-function getQuadrantModId(url: URL): string {
-  return (
-    url.searchParams.get("modId") ??
-    url.searchParams.get("addonId") ??
-    getQuadrantPathValue(url) ??
-    ""
-  ).trim();
-}
-
-function getQuadrantCode(url: URL): string {
-  return (
-    url.searchParams.get("code") ??
-    url.searchParams.get("sharedCode") ??
-    getQuadrantPathValue(url) ??
-    ""
-  ).trim();
 }
 
 function App() {
@@ -344,306 +313,90 @@ function App() {
           return;
         }
         console.log("deep link:", urls);
+        const showUnsupported = () => {
+          contextFunctions.setSnackbar({
+            message: t("unsupportedDownload"),
+            className: "bg-red-700",
+            timeout: 5000,
+          });
+        };
         for (const gottenUrl of urls) {
           try {
-            const url = new URL(gottenUrl);
-            const actionType = url?.protocol;
-            console.log("url:", url);
+            const action = resolveDeepLink(gottenUrl);
+            console.log("deep link action:", gottenUrl, action);
             await currentWindow.setEnabled(true);
             await currentWindow.setFocus();
-          console.log("url protocol:", actionType);
-          if (actionType === "curseforge:") {
-            const action = (
-              url.host || getQuadrantPathParts(url)[0] || ""
-            ).toLowerCase();
-            console.log("CurseForge action:", action);
-            if (action !== "install") {
-                console.log("CurseForge action is not install");
-                contextFunctions.setSnackbar({
-                  message: t("unsupportedDownload"),
-                  className: "bg-red-700",
-                  timeout: 5000,
-                });
-                return;
-              }
-              console.log("Getting mod");
-              const modId = url!.searchParams.get("addonId") ?? "";
-              const fileId = url!.searchParams.get("fileId") ?? undefined;
-              const mod = await getMod(
-                {
-                  deletable: false,
-                  id: modId,
-                  downloadable: true,
-                  showPreviousVersion: false,
-                  versionTarget: "",
-                  modpack: "",
-                  modLoader: ModLoader.Unknown,
-                  selectable: false,
-                  selectUrl: null,
-                },
-                ModSource.CurseForge,
-              );
-              if (mod.modType === ModType.Unknown) {
-                contextFunctions.setSnackbar({
-                  message: t("unsupportedDownload"),
-                  className: "bg-red-700",
-                  timeout: 5000,
-                });
-                return;
-              }
-              const randomString = Math.random().toString(36).substring(2, 10);
 
+            if (action.kind === "none") {
+              continue;
+            }
+
+            if (action.kind === "unsupported") {
+              showUnsupported();
+              return;
+            }
+
+            if (action.kind === "oauthLogin") {
+              const oAuthState = await config.get<string>("oauthState");
+              if (action.providedState !== oAuthState) {
+                return;
+              }
+              if (action.code === null) {
+                return;
+              }
+              await invoke("oauth2_login", {
+                code: action.code,
+                redirectUri: action.redirectUri,
+              });
+              return;
+            }
+
+            if (action.kind === "importModpack") {
+              const randomString = Math.random().toString(36).substring(2, 10);
               contextFunctions.changeContent({
-                content: <ModInstallPage mod={mod} fileId={fileId} />,
+                content: <ShareSyncPage sharedCode={action.code} />,
                 name: randomString,
-                icon: <></>,
-                title: mod.name,
+                icon: <md.MdSync className="duration-0 w-6 h-6" />,
+                title: t("importMods"),
                 style: "",
                 main: false,
               });
-            } else if (actionType === "modrinth:") {
-              console.log(url!.pathname.split("/"));
-
-              const action = url?.pathname.split("/")[2] ?? url?.host ?? "";
-
-              console.log("Modrinth action:", action);
-              if (
-                action.includes("mod") ||
-                action.includes("resourcepack") ||
-                action.includes("shader")
-              ) {
-                console.log("Getting mod");
-                // This gets the slug, not the ID, but it doesn't matter for Modrinth
-                let modId = "";
-                url?.pathname.split("/").forEach((val) => {
-                  if (val !== "") {
-                    modId = val;
-                  }
-                });
-                console.log("Modrinth mod ID: ", modId);
-                const mod = await getMod(
-                  {
-                    deletable: false,
-                    id: modId,
-                    downloadable: true,
-                    showPreviousVersion: false,
-                    versionTarget: "",
-                    modpack: "",
-                    modLoader: ModLoader.Unknown,
-                    selectable: false,
-                    selectUrl: null,
-                  },
-                  ModSource.Modrinth,
-                );
-                if (mod.modType === ModType.Unknown) {
-                  contextFunctions.setSnackbar({
-                    message: t("unsupportedDownload"),
-                    className: "bg-red-700",
-                    timeout: 5000,
-                  });
-                  return;
-                }
-                // Random string
-                const randomString = Math.random()
-                  .toString(36)
-                  .substring(2, 10);
-
-                contextFunctions.changeContent({
-                  content: <ModInstallPage mod={mod} />,
-                  name: randomString,
-                  icon: <></>,
-                  title: mod.name,
-                  style: "",
-                  main: false,
-                });
-                return;
-              }
-              console.log("Modrinth action is not supported");
-              contextFunctions.setSnackbar({
-                message: t("unsupportedDownload"),
-                className: "bg-red-700",
-                timeout: 5000,
-              });
               return;
-            } else if (actionType === "quadrantnext:") {
-              const actions = url!.pathname.split("/");
-              const quadrantAction = getQuadrantAction(url);
-              console.log("Action: " + quadrantAction);
-              if (actions.includes("login") || quadrantAction === "login") {
-                const oAuthState = await config.get<string>("oauthState");
+            }
 
-                const providedState = url!.searchParams.get("state");
-                console.log("State: " + oAuthState);
-                console.log("Provided state: " + providedState);
-                if (providedState !== oAuthState) {
-                  return;
-                }
-                const code = url!.searchParams.get("code");
-                console.log("Code: " + code);
-                if (code === null) {
-                  return;
-                }
-                const redirectUri = gottenUrl.split("#")[0].split("?")[0];
-                await invoke("oauth2_login", {
-                  code: code,
-                  redirectUri: redirectUri,
-                });
-                return;
-              }
-
-              if (quadrantAction === "modrinth") {
-                const modId = getQuadrantModId(url);
-                const fileId = url!.searchParams.get("fileId") ?? undefined;
-                if (!modId) {
-                  contextFunctions.setSnackbar({
-                    message: t("unsupportedDownload"),
-                    className: "bg-red-700",
-                    timeout: 5000,
-                  });
-                  return;
-                }
-                const mod = await getMod(
-                  {
-                    deletable: false,
-                    id: modId,
-                    downloadable: true,
-                    showPreviousVersion: false,
-                    versionTarget: "",
-                    modpack: "",
-                    modLoader: ModLoader.Unknown,
-                    selectable: false,
-                    selectUrl: null,
-                  },
-                  ModSource.Modrinth,
-                );
-                if (mod.modType === ModType.Unknown) {
-                  contextFunctions.setSnackbar({
-                    message: t("unsupportedDownload"),
-                    className: "bg-red-700",
-                    timeout: 5000,
-                  });
-                  return;
-                }
-                const randomString = Math.random()
-                  .toString(36)
-                  .substring(2, 10);
-
-                contextFunctions.changeContent({
-                  content: <ModInstallPage mod={mod} fileId={fileId} />,
-                  name: randomString,
-                  icon: <></>,
-                  title: mod.name,
-                  style: "",
-                  main: false,
-                });
-                return;
-              }
-
-              if (quadrantAction === "curseforge") {
-                const modId = getQuadrantModId(url);
-                const fileId = url!.searchParams.get("fileId") ?? undefined;
-                if (!modId) {
-                  contextFunctions.setSnackbar({
-                    message: t("unsupportedDownload"),
-                    className: "bg-red-700",
-                    timeout: 5000,
-                  });
-                  return;
-                }
-                const mod = await getMod(
-                  {
-                    deletable: false,
-                    id: modId,
-                    downloadable: true,
-                    showPreviousVersion: false,
-                    versionTarget: "",
-                    modpack: "",
-                    modLoader: ModLoader.Unknown,
-                    selectable: false,
-                    selectUrl: null,
-                  },
-                  ModSource.CurseForge,
-                );
-                if (mod.modType === ModType.Unknown) {
-                  contextFunctions.setSnackbar({
-                    message: t("unsupportedDownload"),
-                    className: "bg-red-700",
-                    timeout: 5000,
-                  });
-                  return;
-                }
-                const randomString = Math.random()
-                  .toString(36)
-                  .substring(2, 10);
-
-                contextFunctions.changeContent({
-                  content: <ModInstallPage mod={mod} fileId={fileId} />,
-                  name: randomString,
-                  icon: <></>,
-                  title: mod.name,
-                  style: "",
-                  main: false,
-                });
-                return;
-              }
-
-              if (quadrantAction === "modpack") {
-                const code = getQuadrantCode(url);
-                if (!code) {
-                  contextFunctions.setSnackbar({
-                    message: t("unsupportedDownload"),
-                    className: "bg-red-700",
-                    timeout: 5000,
-                  });
-                  return;
-                }
-                const randomString = Math.random()
-                  .toString(36)
-                  .substring(2, 10);
-
-                contextFunctions.changeContent({
-                  content: <ShareSyncPage sharedCode={code} />,
-                  name: randomString,
-                  icon: <md.MdSync className="duration-0 w-6 h-6" />,
-                  title: t("importMods"),
-                  style: "",
-                  main: false,
-                });
-                return;
-              }
-            } else if (actionType === "https:") {
-              const host = url!.host.toLowerCase();
-              if (
-                host === "usequadrant.dev" ||
-                host === "www.usequadrant.dev"
-              ) {
-                const pathParts = getQuadrantPathParts(url!);
-                if (pathParts[0] === "modpack") {
-                  const code = pathParts[1] ?? "";
-                  if (code && /^\d{7}$/.test(code)) {
-                    const randomString = Math.random()
-                      .toString(36)
-                      .substring(2, 10);
-                    contextFunctions.changeContent({
-                      content: <ShareSyncPage sharedCode={code} />,
-                      name: randomString,
-                      icon: <md.MdSync className="duration-0 w-6 h-6" />,
-                      title: t("importMods"),
-                      style: "",
-                      main: false,
-                    });
-                    return;
-                  }
-                }
-              }
+            const mod = await getMod(
+              {
+                deletable: false,
+                id: action.modId,
+                downloadable: true,
+                showPreviousVersion: false,
+                versionTarget: "",
+                modpack: "",
+                modLoader: ModLoader.Unknown,
+                selectable: false,
+                selectUrl: null,
+              },
+              action.source,
+            );
+            if (mod.modType === ModType.Unknown) {
+              showUnsupported();
+              return;
+            }
+            const randomString = Math.random().toString(36).substring(2, 10);
+            contextFunctions.changeContent({
+              content: <ModInstallPage mod={mod} fileId={action.fileId} />,
+              name: randomString,
+              icon: <></>,
+              title: mod.name,
+              style: "",
+              main: false,
+            });
+            if (action.stopAfter) {
+              return;
             }
           } catch (error) {
             console.error("Failed to handle deep link", error);
-            contextFunctions.setSnackbar({
-              message: t("unsupportedDownload"),
-              className: "bg-red-700",
-              timeout: 5000,
-            });
+            showUnsupported();
           }
         }
       });
@@ -817,54 +570,10 @@ function App() {
       setSnackbarState(newSnackBarState);
       setSnackbarEnabled(true);
 
-      // Convert message to string for comparison (handles React nodes)
-      const messageKey =
-        typeof newSnackBarState.message === "string"
-          ? newSnackBarState.message
-          : JSON.stringify(newSnackBarState.message);
-
-      setSnackbarHistory((prevHistory) => {
-        // Check if there's an existing notification with the same message
-        const existingIndex = prevHistory.findIndex((item) => {
-          const existingKey =
-            typeof item.message === "string"
-              ? item.message
-              : JSON.stringify(item.message);
-          return (
-            existingKey === messageKey &&
-            item.className === newSnackBarState.className
-          );
-        });
-
-        let newHistory: SnackbarHistoryItem[];
-
-        if (existingIndex !== -1) {
-          // Increment count of existing notification and move it to the end
-          const existingItem = prevHistory[existingIndex];
-          newHistory = [
-            ...prevHistory.slice(0, existingIndex),
-            ...prevHistory.slice(existingIndex + 1),
-            { ...existingItem, count: existingItem.count + 1 },
-          ];
-        } else {
-          // Add new notification with count of 1
-          newHistory = [
-            ...prevHistory,
-            {
-              ...newSnackBarState,
-              count: 1,
-              id: Math.random().toString(36).substring(2, 10),
-            },
-          ];
-        }
-
-        // Limit to 5 most recent grouped notifications
-        if (newHistory.length > 5) {
-          newHistory = newHistory.slice(-5);
-        }
-
-        return newHistory;
-      });
+      const id = Math.random().toString(36).substring(2, 10);
+      setSnackbarHistory((prevHistory) =>
+        appendSnackbarHistory(prevHistory, newSnackBarState, id),
+      );
     },
     setSnackbarNoState(newSnackBarState) {
       setSnackbarState(newSnackBarState);

--- a/src/components/Pages/ApplyPage/Apply.test.tsx
+++ b/src/components/Pages/ApplyPage/Apply.test.tsx
@@ -1,0 +1,149 @@
+/** @format */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ModLoader } from "../../../intefaces";
+
+const getVersions = vi.fn();
+const getModpacks = vi.fn();
+const getMinecraftFolder = vi.fn();
+
+const storeGet = vi.fn();
+const joinPath = vi.fn();
+const watch = vi.fn();
+const listen = vi.fn();
+
+vi.mock("../../../tools", () => ({
+  applyModpack: vi.fn(),
+  createModpack: vi.fn(),
+  deleteModpack: vi.fn(),
+  exportModpack: vi.fn(),
+  getMinecraftFolder: (...a: unknown[]) => getMinecraftFolder(...a),
+  getModpacks: (...a: unknown[]) => getModpacks(...a),
+  getVersions: (...a: unknown[]) => getVersions(...a),
+  openModpacksFolder: vi.fn(),
+  shareModpack: vi.fn(),
+  syncModpack: vi.fn(),
+  updateModpack: vi.fn(),
+}));
+
+vi.mock("../../../desktop", () => ({
+  createDesktopStore: () => ({
+    get: (...a: unknown[]) => storeGet(...a),
+  }),
+  joinPath: (...a: unknown[]) => joinPath(...a),
+  listen: (...a: unknown[]) => listen(...a),
+  watch: (...a: unknown[]) => watch(...a),
+}));
+
+// ModpackView is heavy and independently tested; stub it to a marker so the
+// details navigation stays out of scope here.
+vi.mock("../../shared/Pages/ModpackView", () => ({
+  default: ({ name }: { name: string }) => (
+    <div data-testid="modpack-view">{name}</div>
+  ),
+}));
+
+import ApplyPage from "./Apply";
+
+function pack(over: Record<string, unknown>) {
+  return {
+    name: "Pack",
+    version: "1.20.1",
+    modLoader: ModLoader.Fabric,
+    isApplied: false,
+    lastSynced: 0,
+    mods: [],
+    unknownMods: false,
+    ...over,
+  };
+}
+
+// Captures the callback each listen/watch registration is given so a test can
+// drive the backend event by hand.
+let watchCallback: (() => void) | undefined;
+let shareCallback: ((event: unknown) => void) | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  watchCallback = undefined;
+  shareCallback = undefined;
+  getVersions.mockResolvedValue([{ version: "1.20.1", versionType: "release" }]);
+  getModpacks.mockResolvedValue([]);
+  getMinecraftFolder.mockResolvedValue("/mc");
+  storeGet.mockResolvedValue(true);
+  joinPath.mockImplementation(async (...segments: string[]) => segments.join("/"));
+  watch.mockImplementation(async (_path: string, cb: () => void) => {
+    watchCallback = cb;
+    return () => {};
+  });
+  listen.mockImplementation(async (event: string, cb: (e: unknown) => void) => {
+    if (event === "quadrantShareSubmission") {
+      shareCallback = cb;
+    }
+    return () => {};
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ApplyPage", () => {
+  it("renders the modpacks returned by getModpacks", async () => {
+    getModpacks.mockResolvedValue([
+      pack({ name: "Alpha Pack" }),
+      pack({ name: "Beta Pack" }),
+    ]);
+
+    render(<ApplyPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Alpha Pack")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Beta Pack")).toBeInTheDocument();
+  });
+
+  it("registers the folder watch and the share-submission listener", async () => {
+    render(<ApplyPage />);
+
+    await waitFor(() => expect(watch).toHaveBeenCalledTimes(1));
+    // The watch target is the joined Minecraft folder path, with a debounce.
+    expect(watch).toHaveBeenCalledWith(
+      "/mc",
+      expect.any(Function),
+      { delayMs: 50 },
+    );
+    expect(listen).toHaveBeenCalledWith(
+      "quadrantShareSubmission",
+      expect.any(Function),
+    );
+  });
+
+  it("refetches modpacks when the filesystem watch fires", async () => {
+    getModpacks.mockResolvedValue([pack({ name: "Original" })]);
+    render(<ApplyPage />);
+
+    await waitFor(() => expect(screen.getByText("Original")).toBeInTheDocument());
+    await waitFor(() => expect(watchCallback).toBeTypeOf("function"));
+
+    // The next fetch returns a different set; firing the watch must surface it.
+    getModpacks.mockResolvedValue([pack({ name: "Refreshed" })]);
+    watchCallback?.();
+
+    await waitFor(() =>
+      expect(screen.getByText("Refreshed")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows a snackbar-less share confirmation when the share event arrives", async () => {
+    // The share listener drives a snackbar through context; with the default
+    // (no-op) context we only assert the callback was wired and can be invoked
+    // without throwing.
+    render(<ApplyPage />);
+    await waitFor(() => expect(shareCallback).toBeTypeOf("function"));
+    expect(() =>
+      shareCallback?.({ payload: { uses_left: 3 } }),
+    ).not.toThrow();
+  });
+});

--- a/src/components/Pages/CurrentModpackPage/CurrentModpackPage.test.tsx
+++ b/src/components/Pages/CurrentModpackPage/CurrentModpackPage.test.tsx
@@ -1,0 +1,94 @@
+/** @format */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const getModpacks = vi.fn();
+const getMinecraftFolder = vi.fn();
+const joinPath = vi.fn();
+const watch = vi.fn();
+
+vi.mock("../../../tools", () => ({
+  getModpacks: (...a: unknown[]) => getModpacks(...a),
+  getMinecraftFolder: (...a: unknown[]) => getMinecraftFolder(...a),
+}));
+vi.mock("../../../desktop", () => ({
+  joinPath: (...a: unknown[]) => joinPath(...a),
+  watch: (...a: unknown[]) => watch(...a),
+}));
+// ModpackView is heavy and independently tested; stub it to a marker.
+vi.mock("../../shared/Pages/ModpackView", () => ({
+  default: ({ name }: { name: string }) => <div data-testid="modpack-view">{name}</div>,
+}));
+
+import CurrentModpackPage from "./CurrentModpackPage";
+
+function pack(over: Record<string, unknown>) {
+  return {
+    name: "Applied Pack",
+    version: "1.20.1",
+    modLoader: "fabric",
+    isApplied: true,
+    lastSynced: 0,
+    mods: [],
+    unknownMods: [],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getMinecraftFolder.mockResolvedValue("/mc");
+  joinPath.mockResolvedValue("/mc/mods");
+  watch.mockResolvedValue(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CurrentModpackPage", () => {
+  it("renders the applied modpack once loaded", async () => {
+    getModpacks.mockResolvedValue([
+      pack({ name: "Not Applied", isApplied: false }),
+      pack({ name: "Applied Pack", isApplied: true }),
+    ]);
+
+    render(<CurrentModpackPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("modpack-view")).toHaveTextContent(
+        "Applied Pack",
+      ),
+    );
+  });
+
+  it("shows the placeholder when no modpack is applied", async () => {
+    getModpacks.mockResolvedValue([pack({ isApplied: false })]);
+    render(<CurrentModpackPage />);
+    // watch is still set up; the view marker must never appear.
+    await waitFor(() => expect(watch).toHaveBeenCalled());
+    expect(screen.queryByTestId("modpack-view")).not.toBeInTheDocument();
+  });
+
+  it("registers a filesystem watch on the mods folder", async () => {
+    getModpacks.mockResolvedValue([pack({})]);
+    render(<CurrentModpackPage />);
+    await waitFor(() => expect(watch).toHaveBeenCalledTimes(1));
+    expect(watch).toHaveBeenCalledWith(
+      "/mc/mods",
+      expect.any(Function),
+      { delayMs: 500 },
+    );
+  });
+
+  it("tears down the watch on unmount", async () => {
+    const unwatch = vi.fn();
+    watch.mockResolvedValue(unwatch);
+    getModpacks.mockResolvedValue([pack({})]);
+
+    const { unmount } = render(<CurrentModpackPage />);
+    await waitFor(() => expect(watch).toHaveBeenCalled());
+    unmount();
+    await waitFor(() => expect(unwatch).toHaveBeenCalled());
+  });
+});

--- a/src/components/Pages/SearchPage/SearchPage.test.tsx
+++ b/src/components/Pages/SearchPage/SearchPage.test.tsx
@@ -1,0 +1,179 @@
+/** @format */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ModSource, ModType, type IMod } from "../../../intefaces";
+
+const getVersions = vi.fn();
+const getModpacks = vi.fn();
+const getCategories = vi.fn();
+const searchMods = vi.fn();
+
+const storeGet = vi.fn();
+const storeSet = vi.fn();
+const storeSave = vi.fn();
+
+vi.mock("../../../tools", () => ({
+  getVersions: (...a: unknown[]) => getVersions(...a),
+  getModpacks: (...a: unknown[]) => getModpacks(...a),
+  getCategories: (...a: unknown[]) => getCategories(...a),
+  searchMods: (...a: unknown[]) => searchMods(...a),
+}));
+
+vi.mock("../../../desktop", () => ({
+  createDesktopStore: () => ({
+    get: (...a: unknown[]) => storeGet(...a),
+    set: (...a: unknown[]) => storeSet(...a),
+    save: (...a: unknown[]) => storeSave(...a),
+  }),
+}));
+
+// The Mod card is heavy and independently tested; stub it to render just the
+// mod name so result ordering/identity is observable.
+vi.mock("../../shared/Mod", () => ({
+  default: ({ mod }: { mod: IMod }) => (
+    <div data-testid="mod-card">{mod.name}</div>
+  ),
+}));
+
+import SearchPage from "./SearchPage";
+
+function mod(over: Partial<IMod>): IMod {
+  return {
+    name: "Mod",
+    id: "0",
+    downloadCount: 0,
+    version: "",
+    dateModified: "",
+    modType: ModType.Mod,
+    source: ModSource.Modrinth,
+    slug: "",
+    thumbnailUrls: [],
+    url: "",
+    description: "",
+    license: "",
+    modIconUrl: "",
+    downloadable: true,
+    showPreviousVersion: false,
+    newVersion: null,
+    deleteable: false,
+    autoinstallable: false,
+    selectable: false,
+    modpack: null,
+    selectUrl: null,
+    ...over,
+  };
+}
+
+/** A promise whose resolution is controlled by the test. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // jsdom does not implement Element.scrollTo; the results pane scrolls on
+  // page change.
+  Element.prototype.scrollTo = vi.fn();
+  getVersions.mockResolvedValue([
+    { version: "1.20.1", versionType: "release" },
+  ]);
+  getModpacks.mockResolvedValue([]);
+  getCategories.mockResolvedValue([]);
+  searchMods.mockResolvedValue([]);
+  // Only Modrinth enabled → one provider request per search, keeping the
+  // race scenario unambiguous.
+  storeGet.mockImplementation(async (key: string) => {
+    if (key === "curseforge") return false;
+    if (key === "modrinth") return true;
+    return undefined;
+  });
+  storeSet.mockResolvedValue(undefined);
+  storeSave.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SearchPage", () => {
+  it("boots and runs an initial search against the enabled provider", async () => {
+    render(<SearchPage />);
+
+    // The single text field is the query input.
+    await waitFor(() =>
+      expect(screen.getByRole("textbox")).toBeInTheDocument(),
+    );
+    // The mount effect auto-searches; with only Modrinth enabled that provider
+    // must be queried.
+    await waitFor(() => expect(searchMods).toHaveBeenCalled());
+    expect(searchMods).toHaveBeenCalledWith(
+      expect.objectContaining({ source: ModSource.Modrinth }),
+    );
+  });
+
+  it("submitting the form searches with the typed query", async () => {
+    render(<SearchPage />);
+    await waitFor(() => expect(searchMods).toHaveBeenCalled());
+    searchMods.mockClear();
+
+    await userEvent.type(screen.getByRole("textbox"), "sodium");
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() =>
+      expect(searchMods).toHaveBeenCalledWith(
+        expect.objectContaining({ query: "sodium", source: ModSource.Modrinth }),
+      ),
+    );
+  });
+
+  it("a stale in-flight response never overwrites a newer one", async () => {
+    // Controlled promises for the two racing requests, keyed by query so the
+    // empty-query mount searches don't interfere.
+    const pending: { resolve: (v: IMod[]) => void }[] = [];
+    searchMods.mockImplementation((args: { query: string }) => {
+      if (args.query === "race") {
+        const d = deferred<IMod[]>();
+        pending.push({ resolve: d.resolve });
+        return d.promise;
+      }
+      return Promise.resolve<IMod[]>([]);
+    });
+
+    render(<SearchPage />);
+    await waitFor(() => expect(screen.getByRole("textbox")).toBeInTheDocument());
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "race");
+
+    // Request A (stale).
+    await userEvent.keyboard("{Enter}");
+    await waitFor(() => expect(pending).toHaveLength(1));
+
+    // Request B (newer) — supersedes A.
+    await userEvent.keyboard("{Enter}");
+    await waitFor(() => expect(pending).toHaveLength(2));
+
+    // Newer request resolves first and should win.
+    pending[1].resolve([mod({ name: "Newer result", id: "new" })]);
+    await waitFor(() =>
+      expect(screen.getByText("Newer result")).toBeInTheDocument(),
+    );
+
+    // Stale request resolves LAST; the race guard must discard it.
+    pending[0].resolve([mod({ name: "Stale result", id: "old" })]);
+
+    // Give any (incorrect) state update a chance to flush, then assert the
+    // stale payload never replaced the newer results.
+    await Promise.resolve();
+    await waitFor(() =>
+      expect(screen.getByText("Newer result")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Stale result")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Pages/SearchPage/SearchPage.tsx
+++ b/src/components/Pages/SearchPage/SearchPage.tsx
@@ -41,15 +41,11 @@ import {
   loaderSupportsProvider,
 } from "../../../modLoaders";
 
-/** A category/facet unified across providers so a single row can carry both a
- *  CurseForge numeric id and a Modrinth slug. */
-interface MergedCategory {
-  key: string;
-  name: string;
-  header: string;
-  cfId?: string;
-  mrId?: string;
-}
+import {
+  type MergedCategory,
+  mergeCategories,
+  orderResults,
+} from "./searchLogic";
 
 const CONTENT_TYPES: { type: ModType; labelKey: string; Icon: typeof MdSearch }[] =
   [
@@ -85,57 +81,6 @@ interface SavedFilters {
 
 const HEADER_ORDER = ["categories", "resolutions", "features", "performance impact"];
 const PILL_HEADERS = new Set(["resolutions", "performance impact"]);
-
-// Known CurseForge↔Modrinth category-name equivalences, keyed by the normalized
-// (lowercased, punctuation-stripped) name. CurseForge uses long editorial names
-// while Modrinth uses short slugs, so without these aliases the two providers'
-// facets never collapse into one "both" row and picking any category would
-// source-lock the search to a single provider.
-const CATEGORY_ALIASES: Record<string, string> = {
-  worldgeneration: "worldgen",
-  adventureandrpg: "adventure",
-  apiandlibrary: "library",
-  libraryandapi: "library",
-  armortoolsandweapons: "equipment",
-  playertransport: "transportation",
-  utilityqol: "utility",
-  utilityandqol: "utility",
-};
-
-/** Canonical merge token for a category name: lowercased, punctuation-stripped,
- *  then mapped through {@link CATEGORY_ALIASES}. */
-function canonicalName(name: string): string {
-  const compact = name
-    .toLowerCase()
-    .replace(/&/g, "and")
-    .replace(/[^a-z0-9]+/g, "");
-  return CATEGORY_ALIASES[compact] ?? compact;
-}
-
-function mergeCategories(
-  cf: SearchCategory[],
-  mr: SearchCategory[],
-): MergedCategory[] {
-  const map = new Map<string, MergedCategory>();
-  const add = (category: SearchCategory, which: "cf" | "mr") => {
-    const key = `${category.header}:${canonicalName(category.name)}`;
-    let merged = map.get(key);
-    if (!merged) {
-      merged = { key, name: category.name, header: category.header };
-      map.set(key, merged);
-    }
-    if (which === "cf") {
-      merged.cfId = category.id;
-    } else {
-      merged.mrId = category.id;
-    }
-  };
-  // Modrinth first so its shorter, cleaner label wins for merged rows; Map
-  // preserves insertion order, so no separate ordering array is needed.
-  mr.forEach((category) => add(category, "mr"));
-  cf.forEach((category) => add(category, "cf"));
-  return [...map.values()];
-}
 
 export default function SearchPage() {
   const { t, i18n } = useTranslation();
@@ -221,8 +166,7 @@ export default function SearchPage() {
   // Providers return bounded result sets in the requested order. Merge those
   // refreshed lists client-side to produce one ordering across providers.
   const mods = useMemo(
-    () => orderResults(rawLists, sortBy),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    () => orderResults(rawLists, sortBy, i18n.language),
     [rawLists, sortBy, i18n.language],
   );
 
@@ -1137,39 +1081,6 @@ export default function SearchPage() {
     </motion.div>
   );
 
-  function orderResults(lists: IMod[][], key: string): IMod[] {
-    // Relevance: each provider already returns its own ranked list, so preserve
-    // those rankings by round-robin interleaving rather than re-sorting.
-    if (key === "relevance") {
-      const out: IMod[] = [];
-      const longest = lists.reduce((max, list) => Math.max(max, list.length), 0);
-      for (let i = 0; i < longest; i++) {
-        for (const list of lists) {
-          if (i < list.length) out.push(list[i]);
-        }
-      }
-      return out;
-    }
-
-    const flat = lists.flat();
-    if (key === "name") {
-      return flat.sort((a, b) => a.name.localeCompare(b.name, i18n.language));
-    }
-    if (key === "updated") {
-      return flat.sort(
-        (a, b) => dateValue(b.dateModified) - dateValue(a.dateModified),
-      );
-    }
-    // downloads (default)
-    return flat.sort((a, b) => b.downloadCount - a.downloadCount);
-  }
-}
-
-/** Parses an RFC 3339 timestamp to millis; unknown/blank sorts oldest. */
-function dateValue(value: string): number {
-  if (!value) return 0;
-  const parsed = Date.parse(value);
-  return Number.isNaN(parsed) ? 0 : parsed;
 }
 
 function headerTitle(

--- a/src/components/Pages/SearchPage/searchLogic.test.ts
+++ b/src/components/Pages/SearchPage/searchLogic.test.ts
@@ -1,0 +1,124 @@
+/** @format */
+
+import { describe, expect, it } from "vitest";
+import { ModSource, type IMod, type SearchCategory } from "../../../intefaces";
+import {
+  canonicalName,
+  dateValue,
+  mergeCategories,
+  orderResults,
+} from "./searchLogic";
+
+function cat(
+  id: string,
+  name: string,
+  source: ModSource,
+  header = "categories",
+): SearchCategory {
+  return { id, name, header, source };
+}
+
+function mod(over: Partial<IMod>): IMod {
+  return {
+    name: "",
+    id: "",
+    downloadCount: 0,
+    version: "",
+    dateModified: "",
+    slug: "",
+    thumbnailUrls: [],
+    url: "",
+    description: "",
+    license: "",
+    modIconUrl: "",
+    downloadable: true,
+    showPreviousVersion: false,
+    newVersion: null,
+    deleteable: false,
+    autoinstallable: false,
+    selectable: false,
+    modpack: null,
+    selectUrl: null,
+    ...over,
+  } as IMod;
+}
+
+describe("canonicalName", () => {
+  it("lowercases, strips punctuation and maps & to and", () => {
+    expect(canonicalName("World Generation")).toBe("worldgen");
+    expect(canonicalName("Adventure & RPG")).toBe("adventure");
+    expect(canonicalName("API and Library")).toBe("library");
+  });
+
+  it("passes through names with no alias", () => {
+    expect(canonicalName("Magic")).toBe("magic");
+  });
+});
+
+describe("mergeCategories", () => {
+  it("collapses equivalent CurseForge and Modrinth facets into one row", () => {
+    const merged = mergeCategories(
+      [cat("6", "World Generation", ModSource.CurseForge)],
+      [cat("worldgen", "Worldgen", ModSource.Modrinth)],
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0].cfId).toBe("6");
+    expect(merged[0].mrId).toBe("worldgen");
+    // Modrinth is added first, so its cleaner label wins.
+    expect(merged[0].name).toBe("Worldgen");
+  });
+
+  it("keeps provider-only facets separate", () => {
+    const merged = mergeCategories(
+      [cat("1", "Only CF", ModSource.CurseForge)],
+      [cat("only-mr", "Only MR", ModSource.Modrinth)],
+    );
+    expect(merged).toHaveLength(2);
+    expect(merged.map((m) => m.name)).toEqual(["Only MR", "Only CF"]);
+  });
+
+  it("does not merge across different headers", () => {
+    const merged = mergeCategories(
+      [cat("1", "Fast", ModSource.CurseForge, "performance impact")],
+      [cat("fast", "Fast", ModSource.Modrinth, "features")],
+    );
+    expect(merged).toHaveLength(2);
+  });
+});
+
+describe("orderResults", () => {
+  const a = mod({ name: "Alpha", downloadCount: 10, dateModified: "2024-01-01" });
+  const b = mod({ name: "beta", downloadCount: 30, dateModified: "2026-06-01" });
+  const c = mod({ name: "Gamma", downloadCount: 20, dateModified: "2025-01-01" });
+
+  it("interleaves provider lists round-robin for relevance", () => {
+    const result = orderResults([[a, c], [b]], "relevance", "en");
+    expect(result.map((m) => m.name)).toEqual(["Alpha", "beta", "Gamma"]);
+  });
+
+  it("sorts by download count descending", () => {
+    const result = orderResults([[a, b, c]], "downloads", "en");
+    expect(result.map((m) => m.downloadCount)).toEqual([30, 20, 10]);
+  });
+
+  it("sorts by name using the given locale (case-insensitive)", () => {
+    const result = orderResults([[a, b, c]], "name", "en");
+    expect(result.map((m) => m.name)).toEqual(["Alpha", "beta", "Gamma"]);
+  });
+
+  it("sorts by modification date descending", () => {
+    const result = orderResults([[a, b, c]], "updated", "en");
+    expect(result.map((m) => m.name)).toEqual(["beta", "Gamma", "Alpha"]);
+  });
+});
+
+describe("dateValue", () => {
+  it("returns 0 for blank or unparseable input", () => {
+    expect(dateValue("")).toBe(0);
+    expect(dateValue("not a date")).toBe(0);
+  });
+
+  it("parses ISO timestamps to epoch millis", () => {
+    expect(dateValue("2024-01-01T00:00:00Z")).toBe(Date.parse("2024-01-01T00:00:00Z"));
+  });
+});

--- a/src/components/Pages/SearchPage/searchLogic.ts
+++ b/src/components/Pages/SearchPage/searchLogic.ts
@@ -1,0 +1,102 @@
+/** @format */
+
+import type { IMod, SearchCategory } from "../../../intefaces";
+
+/** A category/facet unified across providers so a single row can carry both a
+ *  CurseForge numeric id and a Modrinth slug. */
+export interface MergedCategory {
+  key: string;
+  name: string;
+  header: string;
+  cfId?: string;
+  mrId?: string;
+}
+
+// Known CurseForge↔Modrinth category-name equivalences, keyed by the normalized
+// (lowercased, punctuation-stripped) name. CurseForge uses long editorial names
+// while Modrinth uses short slugs, so without these aliases the two providers'
+// facets never collapse into one "both" row and picking any category would
+// source-lock the search to a single provider.
+export const CATEGORY_ALIASES: Record<string, string> = {
+  worldgeneration: "worldgen",
+  adventureandrpg: "adventure",
+  apiandlibrary: "library",
+  libraryandapi: "library",
+  armortoolsandweapons: "equipment",
+  playertransport: "transportation",
+  utilityqol: "utility",
+  utilityandqol: "utility",
+};
+
+/** Canonical merge token for a category name: lowercased, punctuation-stripped,
+ *  then mapped through {@link CATEGORY_ALIASES}. */
+export function canonicalName(name: string): string {
+  const compact = name
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "");
+  return CATEGORY_ALIASES[compact] ?? compact;
+}
+
+export function mergeCategories(
+  cf: SearchCategory[],
+  mr: SearchCategory[],
+): MergedCategory[] {
+  const map = new Map<string, MergedCategory>();
+  const add = (category: SearchCategory, which: "cf" | "mr") => {
+    const key = `${category.header}:${canonicalName(category.name)}`;
+    let merged = map.get(key);
+    if (!merged) {
+      merged = { key, name: category.name, header: category.header };
+      map.set(key, merged);
+    }
+    if (which === "cf") {
+      merged.cfId = category.id;
+    } else {
+      merged.mrId = category.id;
+    }
+  };
+  // Modrinth first so its shorter, cleaner label wins for merged rows; Map
+  // preserves insertion order, so no separate ordering array is needed.
+  mr.forEach((category) => add(category, "mr"));
+  cf.forEach((category) => add(category, "cf"));
+  return [...map.values()];
+}
+
+export function orderResults(
+  lists: IMod[][],
+  key: string,
+  locale: string,
+): IMod[] {
+  // Relevance: each provider already returns its own ranked list, so preserve
+  // those rankings by round-robin interleaving rather than re-sorting.
+  if (key === "relevance") {
+    const out: IMod[] = [];
+    const longest = lists.reduce((max, list) => Math.max(max, list.length), 0);
+    for (let i = 0; i < longest; i++) {
+      for (const list of lists) {
+        if (i < list.length) out.push(list[i]);
+      }
+    }
+    return out;
+  }
+
+  const flat = lists.flat();
+  if (key === "name") {
+    return flat.sort((a, b) => a.name.localeCompare(b.name, locale));
+  }
+  if (key === "updated") {
+    return flat.sort(
+      (a, b) => dateValue(b.dateModified) - dateValue(a.dateModified),
+    );
+  }
+  // downloads (default)
+  return flat.sort((a, b) => b.downloadCount - a.downloadCount);
+}
+
+/** Parses an RFC 3339 timestamp to millis; unknown/blank sorts oldest. */
+export function dateValue(value: string): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}

--- a/src/components/Pages/SettingsPage/Settings.test.tsx
+++ b/src/components/Pages/SettingsPage/Settings.test.tsx
@@ -1,0 +1,115 @@
+/** @format */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// The config store is a single shared mock so a test can assert what the
+// component persisted through it.
+const storeGet = vi.fn();
+const storeSet = vi.fn();
+const storeSave = vi.fn();
+const storeOnKeyChange = vi.fn();
+const invoke = vi.fn();
+
+const getMinecraftFolder = vi.fn();
+const getDefaultMinecraftFolder = vi.fn();
+const openIn = vi.fn();
+const requestCheckForUpdates = vi.fn();
+
+vi.mock("../../../tools", () => ({
+  getMinecraftFolder: (...a: unknown[]) => getMinecraftFolder(...a),
+  getDefaultMinecraftFolder: (...a: unknown[]) => getDefaultMinecraftFolder(...a),
+  openIn: (...a: unknown[]) => openIn(...a),
+  requestCheckForUpdates: (...a: unknown[]) => requestCheckForUpdates(...a),
+}));
+
+vi.mock("../../../desktop", () => ({
+  createDesktopStore: () => ({
+    get: (...a: unknown[]) => storeGet(...a),
+    set: (...a: unknown[]) => storeSet(...a),
+    save: (...a: unknown[]) => storeSave(...a),
+    onKeyChange: (...a: unknown[]) => storeOnKeyChange(...a),
+  }),
+  getAppVersion: () => Promise.resolve("26.7.0"),
+  getRuntimeName: () => Promise.resolve("Tauri"),
+  getRuntimeVersion: () => Promise.resolve("2.0.0"),
+  invoke: (...a: unknown[]) => invoke(...a),
+  isAutoupdateEnabled: () => Promise.resolve(true),
+  openDialog: vi.fn(),
+}));
+
+import SettingsPage from "./Settings";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Unknown keys resolve to undefined, letting the component apply its
+  // documented defaults.
+  storeGet.mockResolvedValue(undefined);
+  storeSet.mockResolvedValue(undefined);
+  storeSave.mockResolvedValue(undefined);
+  storeOnKeyChange.mockResolvedValue(() => {});
+  getMinecraftFolder.mockResolvedValue("/home/user/.minecraft");
+  invoke.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function renderSettled() {
+  render(<SettingsPage />);
+  // Wait for the async initializeValues() effect to finish loading.
+  await waitFor(() =>
+    expect(screen.getByText("/home/user/.minecraft")).toBeInTheDocument(),
+  );
+}
+
+describe("SettingsPage", () => {
+  it("renders once the initial config load resolves", async () => {
+    await renderSettled();
+    expect(
+      screen.getByText("Some settings require a relaunch!"),
+    ).toBeInTheDocument();
+    // The version line interpolates the mocked runtime values.
+    expect(screen.getByText(/26\.7\.0/)).toBeInTheDocument();
+  });
+
+  it("persists the CurseForge toggle through the config store", async () => {
+    await renderSettled();
+    const toggle = screen.getByRole("switch", { name: "CurseForge" });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await userEvent.click(toggle);
+
+    expect(storeSet).toHaveBeenCalledWith("curseforge", true);
+    expect(storeSave).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(toggle).toHaveAttribute("aria-checked", "true"),
+    );
+  });
+
+  it("persists the Modrinth toggle through the config store", async () => {
+    await renderSettled();
+    const toggle = screen.getByRole("switch", { name: "Modrinth" });
+    await userEvent.click(toggle);
+    expect(storeSet).toHaveBeenCalledWith("modrinth", true);
+  });
+
+  it("persists the developer-mode toggle", async () => {
+    await renderSettled();
+    const toggle = screen.getByRole("switch", { name: "Developer mode" });
+    await userEvent.click(toggle);
+    expect(storeSet).toHaveBeenCalledWith("devMode", true);
+  });
+
+  it("enabling data collection persists the flag and sends telemetry", async () => {
+    await renderSettled();
+    const toggle = screen.getByRole("switch", { name: "Collect data" });
+    await userEvent.click(toggle);
+
+    expect(storeSet).toHaveBeenCalledWith("collectUserData", true);
+    expect(invoke).toHaveBeenCalledWith("send_telemetry");
+    expect(invoke).not.toHaveBeenCalledWith("remove_telemetry");
+  });
+});

--- a/src/components/core/Button.test.tsx
+++ b/src/components/core/Button.test.tsx
@@ -1,0 +1,31 @@
+/** @format */
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Button from "./Button";
+
+describe("Button", () => {
+  it("renders its children", () => {
+    render(<Button onClick={() => {}}>Click me</Button>);
+    expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument();
+  });
+
+  it("fires onClick when pressed", async () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Go</Button>);
+    await userEvent.click(screen.getByRole("button", { name: "Go" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the caller's className and the full-round variant", () => {
+    render(
+      <Button onClick={() => {}} className="custom-class" fullRound>
+        R
+      </Button>,
+    );
+    const button = screen.getByRole("button", { name: "R" });
+    expect(button.className).toContain("custom-class");
+    expect(button.className).toContain("rounded-full");
+  });
+});

--- a/src/components/shared/LoaderOption.test.tsx
+++ b/src/components/shared/LoaderOption.test.tsx
@@ -1,0 +1,37 @@
+/** @format */
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { ModLoader, ModSource } from "../../intefaces";
+import LoaderOptions from "./LoaderOption";
+import { getModLoaderOptions } from "../../modLoaders";
+
+function renderOptions(props: Parameters<typeof LoaderOptions>[0]) {
+  // <option> must live inside a <select> to be valid DOM.
+  const { container } = render(
+    <select>
+      <LoaderOptions {...props} />
+    </select>,
+  );
+  return Array.from(container.querySelectorAll("option"));
+}
+
+describe("LoaderOptions", () => {
+  it("renders the unknown placeholder plus every loader for the default providers", () => {
+    const options = renderOptions({ loader: ModLoader.Unknown });
+    // "-" placeholder + all loader options.
+    expect(options).toHaveLength(1 + getModLoaderOptions().length);
+    expect(options[0]).toHaveValue(ModLoader.Unknown);
+  });
+
+  it("restricts options to the given provider", () => {
+    const options = renderOptions({
+      loader: ModLoader.Unknown,
+      providers: [ModSource.CurseForge],
+    });
+    const labels = options.slice(1).map((o) => o.textContent);
+    // Modrinth-only loaders such as Rift must not appear.
+    expect(labels).not.toContain("Rift");
+    expect(labels).toContain("Fabric");
+  });
+});

--- a/src/components/shared/Notifications.test.tsx
+++ b/src/components/shared/Notifications.test.tsx
@@ -1,0 +1,199 @@
+/** @format */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { AccountNotification, SnackbarHistoryItem } from "../../intefaces";
+
+const getAccountInfo = vi.fn();
+const getNews = vi.fn();
+const answerInvite = vi.fn();
+const openIn = vi.fn();
+const readNotification = vi.fn();
+
+const storeGet = vi.fn();
+const storeOnKeyChange = vi.fn();
+const listen = vi.fn();
+
+vi.mock("../../tools", () => ({
+  answerInvite: (...a: unknown[]) => answerInvite(...a),
+  getAccountInfo: (...a: unknown[]) => getAccountInfo(...a),
+  getNews: (...a: unknown[]) => getNews(...a),
+  openIn: (...a: unknown[]) => openIn(...a),
+  readNotification: (...a: unknown[]) => readNotification(...a),
+}));
+
+vi.mock("../../desktop", () => ({
+  createDesktopStore: () => ({
+    get: (...a: unknown[]) => storeGet(...a),
+    onKeyChange: (...a: unknown[]) => storeOnKeyChange(...a),
+  }),
+  listen: (...a: unknown[]) => listen(...a),
+}));
+
+import Notifications from "./Notifications";
+
+// headlessui's anchored PopoverPanel positions via ResizeObserver, which jsdom
+// does not implement. A minimal stub keeps the panel from throwing on open.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function historyItem(over: Partial<SnackbarHistoryItem>): SnackbarHistoryItem {
+  return {
+    message: "Something happened",
+    className: "bg-emerald-600 rounded-4xl",
+    timeout: 5000,
+    count: 1,
+    id: Math.random().toString(36).slice(2),
+    ...over,
+  };
+}
+
+function notification(
+  over: Partial<AccountNotification>,
+): AccountNotification {
+  return {
+    notification_id: "n1",
+    user_id: "u1",
+    notification_type: "generic",
+    resource_id: null,
+    message: "A plain notification",
+    created_at: "",
+    created_at_unix: 0,
+    read: false,
+    ...over,
+  };
+}
+
+// The callback registered for the "refreshNotifications" backend event, so a
+// test can push notifications the way the host would.
+let refreshNotifications: ((event: { payload: unknown }) => void) | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+  refreshNotifications = undefined;
+  getAccountInfo.mockResolvedValue({
+    id: "1",
+    name: "me",
+    login: "me",
+    email: "",
+    quadrant_sync_limit: 0,
+    quadrant_share_limit: 0,
+    notifications: [],
+  });
+  getNews.mockResolvedValue([]);
+  storeGet.mockResolvedValue(true);
+  storeOnKeyChange.mockResolvedValue(() => {});
+  listen.mockImplementation(
+    async (event: string, cb: (e: { payload: unknown }) => void) => {
+      if (event === "refreshNotifications") {
+        refreshNotifications = cb;
+      }
+      return () => {};
+    },
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function renderNotifications(history: SnackbarHistoryItem[] = []) {
+  const setSnackbarHistory = vi.fn();
+  render(
+    <Notifications
+      snackBarHistory={history}
+      setSnackbarHistory={setSnackbarHistory}
+    />,
+  );
+  return { setSnackbarHistory };
+}
+
+async function openPanel() {
+  // The only button before opening is the bell toggle.
+  await userEvent.click(screen.getByRole("button"));
+}
+
+describe("Notifications", () => {
+  it("renders the snackbar history with per-item repeat counts", async () => {
+    renderNotifications([
+      historyItem({ id: "a", message: "Repeated event", count: 3 }),
+      historyItem({ id: "b", message: "One-off event", count: 1 }),
+    ]);
+    await waitFor(() => expect(listen).toHaveBeenCalled());
+
+    await openPanel();
+
+    expect(await screen.findByText("Repeated event")).toBeInTheDocument();
+    expect(screen.getByText("One-off event")).toBeInTheDocument();
+    // Grouped items expose an "Nx" badge; singletons must not.
+    expect(screen.getByText("3x")).toBeInTheDocument();
+    expect(screen.queryByText("1x")).not.toBeInTheDocument();
+  });
+
+  it("renders account notifications pushed via the refresh event", async () => {
+    renderNotifications();
+    await waitFor(() => expect(refreshNotifications).toBeTypeOf("function"));
+
+    refreshNotifications?.({
+      payload: [
+        notification({
+          notification_id: "n1",
+          message: "You were mentioned",
+          created_at_unix: 2,
+        }),
+      ],
+    });
+
+    await openPanel();
+    expect(await screen.findByText("You were mentioned")).toBeInTheDocument();
+  });
+
+  it("sorts pushed notifications newest-first", async () => {
+    renderNotifications();
+    await waitFor(() => expect(refreshNotifications).toBeTypeOf("function"));
+
+    refreshNotifications?.({
+      payload: [
+        notification({
+          notification_id: "older",
+          message: "Older note",
+          created_at_unix: 1,
+        }),
+        notification({
+          notification_id: "newer",
+          message: "Newer note",
+          created_at_unix: 5,
+        }),
+      ],
+    });
+
+    await openPanel();
+    await screen.findByText("Newer note");
+
+    const older = screen.getByText("Older note");
+    const newer = screen.getByText("Newer note");
+    // Newer entry appears earlier in document order.
+    expect(
+      newer.compareDocumentPosition(older) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("clears the snackbar history when the clear button is pressed", async () => {
+    const { setSnackbarHistory } = renderNotifications([
+      historyItem({ id: "a", message: "Repeated event", count: 3 }),
+    ]);
+    await waitFor(() => expect(listen).toHaveBeenCalled());
+    await openPanel();
+
+    const clearButton = await screen.findByRole("button", { name: /clear/i });
+    await userEvent.click(clearButton);
+    expect(setSnackbarHistory).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/deepLinks.test.ts
+++ b/src/deepLinks.test.ts
@@ -1,0 +1,155 @@
+/** @format */
+
+import { describe, expect, it } from "vitest";
+import { ModSource } from "./intefaces";
+import {
+  getQuadrantCode,
+  getQuadrantModId,
+  resolveDeepLink,
+} from "./deepLinks";
+
+describe("resolveDeepLink — curseforge scheme", () => {
+  it("resolves an install link to a CurseForge mod that keeps iterating", () => {
+    const action = resolveDeepLink(
+      "curseforge://install?addonId=238222&fileId=99",
+    );
+    expect(action).toEqual({
+      kind: "installMod",
+      source: ModSource.CurseForge,
+      modId: "238222",
+      fileId: "99",
+      stopAfter: false,
+    });
+  });
+
+  it("marks non-install actions as unsupported", () => {
+    expect(resolveDeepLink("curseforge://open?addonId=1").kind).toBe(
+      "unsupported",
+    );
+  });
+});
+
+describe("resolveDeepLink — modrinth scheme", () => {
+  it("resolves a mod link using the last path segment as the slug", () => {
+    const action = resolveDeepLink("modrinth://mod/sodium");
+    expect(action).toEqual({
+      kind: "installMod",
+      source: ModSource.Modrinth,
+      modId: "sodium",
+      stopAfter: true,
+    });
+  });
+
+  it("supports resourcepack and shader content types", () => {
+    expect(resolveDeepLink("modrinth://resourcepack/faithful").kind).toBe(
+      "installMod",
+    );
+    expect(resolveDeepLink("modrinth://shader/complementary").kind).toBe(
+      "installMod",
+    );
+  });
+
+  it("marks other modrinth actions as unsupported", () => {
+    expect(resolveDeepLink("modrinth://user/jellysquid").kind).toBe(
+      "unsupported",
+    );
+  });
+});
+
+describe("resolveDeepLink — quadrantnext scheme", () => {
+  it("resolves an OAuth login callback", () => {
+    const action = resolveDeepLink(
+      "quadrantnext://login?state=abc&code=xyz#fragment",
+    );
+    expect(action).toEqual({
+      kind: "oauthLogin",
+      providedState: "abc",
+      code: "xyz",
+      redirectUri: "quadrantnext://login",
+    });
+  });
+
+  it("resolves modrinth and curseforge mod actions", () => {
+    expect(resolveDeepLink("quadrantnext://modrinth?modId=sodium")).toEqual({
+      kind: "installMod",
+      source: ModSource.Modrinth,
+      modId: "sodium",
+      fileId: undefined,
+      stopAfter: true,
+    });
+    expect(
+      resolveDeepLink("quadrantnext://curseforge?addonId=1&fileId=2"),
+    ).toEqual({
+      kind: "installMod",
+      source: ModSource.CurseForge,
+      modId: "1",
+      fileId: "2",
+      stopAfter: true,
+    });
+  });
+
+  it("flags a mod action with no id as unsupported", () => {
+    expect(resolveDeepLink("quadrantnext://modrinth").kind).toBe("unsupported");
+  });
+
+  it("resolves a modpack share code", () => {
+    expect(resolveDeepLink("quadrantnext://modpack?code=1234567")).toEqual({
+      kind: "importModpack",
+      code: "1234567",
+    });
+  });
+
+  it("returns none for unrecognized quadrantnext actions", () => {
+    expect(resolveDeepLink("quadrantnext://mystery").kind).toBe("none");
+  });
+});
+
+describe("resolveDeepLink — https scheme", () => {
+  it("imports a 7-digit modpack code from the marketing domain", () => {
+    expect(
+      resolveDeepLink("https://usequadrant.dev/modpack/1234567"),
+    ).toEqual({ kind: "importModpack", code: "1234567" });
+    expect(
+      resolveDeepLink("https://www.usequadrant.dev/modpack/7654321").kind,
+    ).toBe("importModpack");
+  });
+
+  it("ignores non-7-digit codes and other hosts", () => {
+    expect(resolveDeepLink("https://usequadrant.dev/modpack/12").kind).toBe(
+      "none",
+    );
+    expect(
+      resolveDeepLink("https://evil.example.com/modpack/1234567").kind,
+    ).toBe("none");
+  });
+});
+
+describe("resolveDeepLink — invalid input", () => {
+  it("throws on a non-URL string (caller catches and shows the error snackbar)", () => {
+    expect(() => resolveDeepLink("not a url")).toThrow();
+  });
+
+  it("returns none for unrelated schemes", () => {
+    expect(resolveDeepLink("mailto:someone@example.com").kind).toBe("none");
+  });
+});
+
+describe("helper parsers", () => {
+  it("getQuadrantModId prefers modId, then addonId, then the path value", () => {
+    expect(getQuadrantModId(new URL("quadrantnext://modrinth?modId=a"))).toBe(
+      "a",
+    );
+    expect(
+      getQuadrantModId(new URL("quadrantnext://curseforge?addonId=b")),
+    ).toBe("b");
+  });
+
+  it("getQuadrantCode prefers code, then sharedCode", () => {
+    expect(getQuadrantCode(new URL("quadrantnext://modpack?code=111"))).toBe(
+      "111",
+    );
+    expect(
+      getQuadrantCode(new URL("quadrantnext://modpack?sharedCode=222")),
+    ).toBe("222");
+  });
+});

--- a/src/deepLinks.ts
+++ b/src/deepLinks.ts
@@ -1,0 +1,169 @@
+/** @format */
+
+import { ModSource } from "./intefaces";
+
+export function getQuadrantPathParts(url: URL): string[] {
+  return url.pathname.split("/").filter((part) => part.trim().length > 0);
+}
+
+export function getQuadrantAction(url: URL): string {
+  const pathAction = getQuadrantPathParts(url)[0];
+  return (url.host || pathAction || "").toLowerCase();
+}
+
+export function getQuadrantPathValue(url: URL): string | undefined {
+  const pathParts = getQuadrantPathParts(url);
+  return url.host ? pathParts[0] : pathParts[1];
+}
+
+export function getQuadrantModId(url: URL): string {
+  return (
+    url.searchParams.get("modId") ??
+    url.searchParams.get("addonId") ??
+    getQuadrantPathValue(url) ??
+    ""
+  ).trim();
+}
+
+export function getQuadrantCode(url: URL): string {
+  return (
+    url.searchParams.get("code") ??
+    url.searchParams.get("sharedCode") ??
+    getQuadrantPathValue(url) ??
+    ""
+  ).trim();
+}
+
+export type DeepLinkAction =
+  /**
+   * Open the install page for a mod. `stopAfter` mirrors the historical
+   * handler: most schemes stop processing further URLs after an install,
+   * but the bare `curseforge:` scheme kept iterating.
+   */
+  | {
+      kind: "installMod";
+      source: ModSource;
+      modId: string;
+      fileId?: string;
+      stopAfter: boolean;
+    }
+  /** OAuth redirect; the caller still validates `providedState`. */
+  | {
+      kind: "oauthLogin";
+      providedState: string | null;
+      code: string | null;
+      redirectUri: string;
+    }
+  /** Open the shared-modpack import page. */
+  | { kind: "importModpack"; code: string }
+  /** Recognized scheme but unusable payload: show the error snackbar and stop. */
+  | { kind: "unsupported" }
+  /** Not a Quadrant link: skip silently and keep processing. */
+  | { kind: "none" };
+
+/**
+ * Classifies a deep-link URL into the action the app should take.
+ * Throws if `rawUrl` is not a valid URL (matching `new URL`).
+ */
+export function resolveDeepLink(rawUrl: string): DeepLinkAction {
+  const url = new URL(rawUrl);
+
+  switch (url.protocol) {
+    case "curseforge:": {
+      const action = (url.host || getQuadrantPathParts(url)[0] || "")
+        .toLowerCase();
+      if (action !== "install") {
+        return { kind: "unsupported" };
+      }
+      return {
+        kind: "installMod",
+        source: ModSource.CurseForge,
+        modId: url.searchParams.get("addonId") ?? "",
+        fileId: url.searchParams.get("fileId") ?? undefined,
+        stopAfter: false,
+      };
+    }
+
+    case "modrinth:": {
+      const action = url.pathname.split("/")[2] ?? url.host ?? "";
+      if (
+        action.includes("mod") ||
+        action.includes("resourcepack") ||
+        action.includes("shader")
+      ) {
+        // This gets the slug, not the ID, but it doesn't matter for Modrinth
+        let modId = "";
+        url.pathname.split("/").forEach((val) => {
+          if (val !== "") {
+            modId = val;
+          }
+        });
+        return {
+          kind: "installMod",
+          source: ModSource.Modrinth,
+          modId,
+          stopAfter: true,
+        };
+      }
+      return { kind: "unsupported" };
+    }
+
+    case "quadrantnext:": {
+      const actions = url.pathname.split("/");
+      const quadrantAction = getQuadrantAction(url);
+
+      if (actions.includes("login") || quadrantAction === "login") {
+        return {
+          kind: "oauthLogin",
+          providedState: url.searchParams.get("state"),
+          code: url.searchParams.get("code"),
+          redirectUri: rawUrl.split("#")[0].split("?")[0],
+        };
+      }
+
+      if (quadrantAction === "modrinth" || quadrantAction === "curseforge") {
+        const modId = getQuadrantModId(url);
+        if (!modId) {
+          return { kind: "unsupported" };
+        }
+        return {
+          kind: "installMod",
+          source:
+            quadrantAction === "modrinth"
+              ? ModSource.Modrinth
+              : ModSource.CurseForge,
+          modId,
+          fileId: url.searchParams.get("fileId") ?? undefined,
+          stopAfter: true,
+        };
+      }
+
+      if (quadrantAction === "modpack") {
+        const code = getQuadrantCode(url);
+        if (!code) {
+          return { kind: "unsupported" };
+        }
+        return { kind: "importModpack", code };
+      }
+
+      return { kind: "none" };
+    }
+
+    case "https:": {
+      const host = url.host.toLowerCase();
+      if (host === "usequadrant.dev" || host === "www.usequadrant.dev") {
+        const pathParts = getQuadrantPathParts(url);
+        if (pathParts[0] === "modpack") {
+          const code = pathParts[1] ?? "";
+          if (code && /^\d{7}$/.test(code)) {
+            return { kind: "importModpack", code };
+          }
+        }
+      }
+      return { kind: "none" };
+    }
+
+    default:
+      return { kind: "none" };
+  }
+}

--- a/src/desktop/browser.ts
+++ b/src/desktop/browser.ts
@@ -52,9 +52,7 @@ class BrowserWindowAdapter implements DesktopWindowAdapter {
     window.focus();
   }
   async unminimize(): Promise<void> {}
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async setProgressBar(_state: DesktopWindowProgressState): Promise<void> {}
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async setDecorations(_decorations: boolean): Promise<void> {}
 }
 
@@ -62,7 +60,6 @@ export const browserRuntime: RuntimeAdapter = {
   createStore(name: string) {
     return new BrowserStoreAdapter(name);
   },
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async invoke<T>(_command: string): Promise<T> {
     unsupported("invoke");
   },
@@ -115,7 +112,6 @@ export const browserRuntime: RuntimeAdapter = {
   async onOpenUrl() {
     return () => {};
   },
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async startOAuthServer(_options: DesktopOAuthStartOptions) {
     unsupported("startOAuthServer");
   },

--- a/src/desktop/runtime.ts
+++ b/src/desktop/runtime.ts
@@ -21,3 +21,11 @@ export function getRuntimeAdapter(): Promise<RuntimeAdapter> {
   }
   return runtimePromise;
 }
+
+/**
+ * Test-only escape hatch: inject a fake adapter, or pass `undefined` to
+ * clear the memoized runtime so the next call re-resolves it.
+ */
+export function __setRuntimeForTests(adapter: RuntimeAdapter | undefined) {
+  runtimePromise = adapter ? Promise.resolve(adapter) : undefined;
+}

--- a/src/intefaces.tsx
+++ b/src/intefaces.tsx
@@ -1,4 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/** @format */
+
 import { createContext } from "react";
 
 export interface IContentContext {

--- a/src/locales/locales.test.ts
+++ b/src/locales/locales.test.ts
@@ -1,0 +1,32 @@
+/** @format */
+
+import { describe, expect, it } from "vitest";
+import en from "./en.json";
+import tr from "./tr.json";
+import uk from "./uk.json";
+
+const locales = { en, tr, uk } as const;
+const reference = "en";
+
+describe("locale files", () => {
+  const referenceKeys = Object.keys(locales[reference]).sort();
+
+  it.each(Object.keys(locales).filter((l) => l !== reference))(
+    "%s has exactly the same keys as en",
+    (locale) => {
+      const keys = Object.keys(
+        locales[locale as keyof typeof locales],
+      ).sort();
+      const missing = referenceKeys.filter((k) => !keys.includes(k));
+      const extra = keys.filter((k) => !referenceKeys.includes(k));
+      expect({ missing, extra }).toEqual({ missing: [], extra: [] });
+    },
+  );
+
+  it.each(Object.keys(locales))("%s has no empty values", (locale) => {
+    const empty = Object.entries(locales[locale as keyof typeof locales])
+      .filter(([, value]) => typeof value !== "string" || value.trim() === "")
+      .map(([key]) => key);
+    expect(empty).toEqual([]);
+  });
+});

--- a/src/modLoaders.test.ts
+++ b/src/modLoaders.test.ts
@@ -1,0 +1,109 @@
+/** @format */
+
+import { describe, expect, it } from "vitest";
+import { ModLoader, ModSource } from "./intefaces";
+import {
+  MOD_LOADER_OPTIONS,
+  getModLoaderOptions,
+  loaderProvidersForSource,
+  loaderProvidersFromSettings,
+  loaderSupportsProvider,
+} from "./modLoaders";
+
+describe("getModLoaderOptions", () => {
+  it("returns every option when no provider filter is given", () => {
+    expect(getModLoaderOptions()).toEqual(MOD_LOADER_OPTIONS);
+  });
+
+  it("treats an empty provider list as 'all providers'", () => {
+    expect(getModLoaderOptions([])).toEqual(MOD_LOADER_OPTIONS);
+  });
+
+  it("only returns CurseForge-capable loaders for a CurseForge-only filter", () => {
+    const options = getModLoaderOptions([ModSource.CurseForge]);
+    expect(options.map((o) => o.value)).toEqual([
+      ModLoader.Fabric,
+      ModLoader.Forge,
+      ModLoader.NeoForge,
+      ModLoader.LiteLoader,
+      ModLoader.Quilt,
+    ]);
+  });
+
+  it("returns all options for a Modrinth-only filter (Modrinth supports every loader)", () => {
+    expect(getModLoaderOptions([ModSource.Modrinth])).toEqual(
+      MOD_LOADER_OPTIONS,
+    );
+  });
+});
+
+describe("loaderProvidersFromSettings", () => {
+  it("maps enabled settings to their providers", () => {
+    expect(loaderProvidersFromSettings(true, false)).toEqual([
+      ModSource.CurseForge,
+    ]);
+    expect(loaderProvidersFromSettings(false, true)).toEqual([
+      ModSource.Modrinth,
+    ]);
+    expect(loaderProvidersFromSettings(true, true)).toEqual([
+      ModSource.CurseForge,
+      ModSource.Modrinth,
+    ]);
+  });
+
+  it("falls back to all providers when nothing is enabled", () => {
+    expect(loaderProvidersFromSettings(false, false)).toEqual([
+      ModSource.CurseForge,
+      ModSource.Modrinth,
+    ]);
+    expect(loaderProvidersFromSettings(null, undefined)).toEqual([
+      ModSource.CurseForge,
+      ModSource.Modrinth,
+    ]);
+  });
+});
+
+describe("loaderProvidersForSource", () => {
+  it("returns the single matching provider for a provider source", () => {
+    expect(loaderProvidersForSource(ModSource.CurseForge)).toEqual([
+      ModSource.CurseForge,
+    ]);
+    expect(loaderProvidersForSource(ModSource.Modrinth)).toEqual([
+      ModSource.Modrinth,
+    ]);
+  });
+
+  it("returns all providers for non-provider sources", () => {
+    expect(loaderProvidersForSource(ModSource.Online)).toEqual([
+      ModSource.CurseForge,
+      ModSource.Modrinth,
+    ]);
+  });
+});
+
+describe("loaderSupportsProvider", () => {
+  it("always matches when the loader is unknown or empty", () => {
+    expect(loaderSupportsProvider(ModLoader.Unknown, ModSource.CurseForge)).toBe(
+      true,
+    );
+    expect(loaderSupportsProvider("", ModSource.Modrinth)).toBe(true);
+  });
+
+  it("checks the provider list of the loader", () => {
+    expect(loaderSupportsProvider(ModLoader.Rift, ModSource.Modrinth)).toBe(
+      true,
+    );
+    expect(loaderSupportsProvider(ModLoader.Rift, ModSource.CurseForge)).toBe(
+      false,
+    );
+    expect(loaderSupportsProvider(ModLoader.Quilt, ModSource.CurseForge)).toBe(
+      true,
+    );
+  });
+
+  it("rejects loaders that are not in the option table", () => {
+    expect(loaderSupportsProvider("not-a-loader", ModSource.Modrinth)).toBe(
+      false,
+    );
+  });
+});

--- a/src/snackbar.test.ts
+++ b/src/snackbar.test.ts
@@ -1,0 +1,49 @@
+/** @format */
+
+import { describe, expect, it } from "vitest";
+import type { SnackbarHistoryItem, SnackbarState } from "./intefaces";
+import { SNACKBAR_HISTORY_LIMIT, appendSnackbarHistory } from "./snackbar";
+
+function state(message: string, className = "bg-red-700"): SnackbarState {
+  return { message, className, timeout: 5000 };
+}
+
+describe("appendSnackbarHistory", () => {
+  it("adds a new entry with count 1 and the given id", () => {
+    const history = appendSnackbarHistory([], state("hello"), "id-1");
+    expect(history).toHaveLength(1);
+    expect(history[0].count).toBe(1);
+    expect(history[0].id).toBe("id-1");
+  });
+
+  it("increments the count and moves a repeated message to the end", () => {
+    const existing: SnackbarHistoryItem[] = [
+      { ...state("a"), count: 1, id: "a" },
+      { ...state("b"), count: 1, id: "b" },
+    ];
+    const next = appendSnackbarHistory(existing, state("a"), "a2");
+    expect(next.map((i) => i.id)).toEqual(["b", "a"]);
+    expect(next[1].count).toBe(2);
+    // A repeat must not mint a new id.
+    expect(next.find((i) => i.id === "a2")).toBeUndefined();
+  });
+
+  it("treats different classNames as distinct notifications", () => {
+    const existing: SnackbarHistoryItem[] = [
+      { ...state("a", "bg-red-700"), count: 1, id: "a" },
+    ];
+    const next = appendSnackbarHistory(existing, state("a", "bg-green-700"), "b");
+    expect(next).toHaveLength(2);
+  });
+
+  it("caps history at the most recent SNACKBAR_HISTORY_LIMIT groups", () => {
+    let history: SnackbarHistoryItem[] = [];
+    for (let i = 0; i < SNACKBAR_HISTORY_LIMIT + 3; i++) {
+      history = appendSnackbarHistory(history, state(`m${i}`), `id-${i}`);
+    }
+    expect(history).toHaveLength(SNACKBAR_HISTORY_LIMIT);
+    expect(history[history.length - 1].id).toBe(
+      `id-${SNACKBAR_HISTORY_LIMIT + 2}`,
+    );
+  });
+});

--- a/src/snackbar.ts
+++ b/src/snackbar.ts
@@ -1,0 +1,48 @@
+/** @format */
+
+import type { SnackbarHistoryItem, SnackbarState } from "./intefaces";
+
+export const SNACKBAR_HISTORY_LIMIT = 5;
+
+function messageKeyOf(state: {
+  message: SnackbarState["message"];
+}): string {
+  return typeof state.message === "string"
+    ? state.message
+    : JSON.stringify(state.message);
+}
+
+/**
+ * Groups a new snackbar into the history: repeats of the same
+ * message+className bump the count and move to the end; the history is
+ * capped at the most recent SNACKBAR_HISTORY_LIMIT groups.
+ */
+export function appendSnackbarHistory(
+  prevHistory: SnackbarHistoryItem[],
+  newState: SnackbarState,
+  id: string,
+): SnackbarHistoryItem[] {
+  const messageKey = messageKeyOf(newState);
+  const existingIndex = prevHistory.findIndex(
+    (item) =>
+      messageKeyOf(item) === messageKey &&
+      item.className === newState.className,
+  );
+
+  let newHistory: SnackbarHistoryItem[];
+  if (existingIndex !== -1) {
+    const existingItem = prevHistory[existingIndex];
+    newHistory = [
+      ...prevHistory.slice(0, existingIndex),
+      ...prevHistory.slice(existingIndex + 1),
+      { ...existingItem, count: existingItem.count + 1 },
+    ];
+  } else {
+    newHistory = [...prevHistory, { ...newState, count: 1, id }];
+  }
+
+  if (newHistory.length > SNACKBAR_HISTORY_LIMIT) {
+    newHistory = newHistory.slice(-SNACKBAR_HISTORY_LIMIT);
+  }
+  return newHistory;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,3 @@
+/** @format */
+
+import "@testing-library/jest-dom/vitest";

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -1,0 +1,182 @@
+/** @format */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ModSource } from "./intefaces";
+
+const invoke = vi.fn();
+const platform = vi.fn();
+const openExternal = vi.fn();
+const openDialog = vi.fn();
+const writeClipboardText = vi.fn();
+const storeGet = vi.fn();
+
+vi.mock("./desktop", () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+  platform: (...args: unknown[]) => platform(...args),
+  openExternal: (...args: unknown[]) => openExternal(...args),
+  openDialog: (...args: unknown[]) => openDialog(...args),
+  writeClipboardText: (...args: unknown[]) => writeClipboardText(...args),
+  requestCheckForUpdates: vi.fn(),
+  createDesktopStore: () => ({ get: (...args: unknown[]) => storeGet(...args) }),
+}));
+
+// Imported after the mock is registered.
+import {
+  applyModpack,
+  exportModpack,
+  getMod,
+  getModDependencies,
+  getModOwners,
+  getModpacks,
+  shareModpack,
+  shuffle,
+} from "./tools";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function modpack(over: Partial<Record<string, unknown>>) {
+  return {
+    name: "pack",
+    version: "1.20.1",
+    modLoader: "fabric",
+    lastSynced: 0,
+    isApplied: false,
+    ...over,
+  };
+}
+
+describe("getModpacks", () => {
+  it("sorts by lastSynced descending", async () => {
+    invoke.mockResolvedValue([
+      modpack({ name: "old", lastSynced: 1 }),
+      modpack({ name: "new", lastSynced: 3 }),
+      modpack({ name: "mid", lastSynced: 2 }),
+    ]);
+    const res = await getModpacks();
+    expect(res.map((m) => m.name)).toEqual(["new", "mid", "old"]);
+    expect(invoke).toHaveBeenCalledWith("get_modpacks", { hideFree: true });
+  });
+
+  it("floats the applied modpack to the front regardless of sync time", async () => {
+    invoke.mockResolvedValue([
+      modpack({ name: "a", lastSynced: 3 }),
+      modpack({ name: "applied", lastSynced: 1, isApplied: true }),
+      modpack({ name: "b", lastSynced: 2 }),
+    ]);
+    const res = await getModpacks();
+    expect(res[0].name).toBe("applied");
+  });
+
+  it("filters by a case-insensitive substring across name, version and loader", async () => {
+    invoke.mockResolvedValue([
+      modpack({ name: "Fancy", version: "1.20.1", modLoader: "fabric" }),
+      modpack({ name: "Other", version: "1.19.2", modLoader: "forge" }),
+    ]);
+    const byLoader = await getModpacks(true, "fabric");
+    expect(byLoader.map((m) => m.name)).toEqual(["Fancy"]);
+
+    const byVersion = await getModpacks(true, "1.19");
+    expect(byVersion.map((m) => m.name)).toEqual(["Other"]);
+  });
+
+  it("passes hideFree through to the backend", async () => {
+    invoke.mockResolvedValue([]);
+    await getModpacks(false);
+    expect(invoke).toHaveBeenCalledWith("get_modpacks", { hideFree: false });
+  });
+});
+
+describe("source dispatch", () => {
+  it("getMod routes to the provider-specific command", async () => {
+    invoke.mockResolvedValue({ name: "m" });
+    await getMod({ id: "x" } as never, ModSource.CurseForge);
+    expect(invoke).toHaveBeenCalledWith("get_mod_curseforge", {
+      args: { id: "x" },
+    });
+
+    await getMod({ id: "y" } as never, ModSource.Modrinth);
+    expect(invoke).toHaveBeenCalledWith("get_mod_modrinth", {
+      args: { id: "y" },
+    });
+  });
+
+  it("getMod throws for an unknown source", async () => {
+    await expect(getMod({ id: "x" } as never, ModSource.Online)).rejects.toThrow();
+  });
+
+  it("getModOwners returns [] for a non-provider source without invoking", async () => {
+    const owners = await getModOwners(ModSource.Online, "1");
+    expect(owners).toEqual([]);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("getModDependencies routes per provider", async () => {
+    invoke.mockResolvedValue([]);
+    await getModDependencies(ModSource.Modrinth, "42");
+    expect(invoke).toHaveBeenCalledWith("get_mod_deps_modrinth", { id: "42" });
+  });
+});
+
+describe("applyModpack", () => {
+  it("resolves on success without touching the browser", async () => {
+    invoke.mockResolvedValue(undefined);
+    await applyModpack("pack");
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it("opens the Windows help page and rethrows on failure", async () => {
+    invoke.mockRejectedValue(new Error("boom"));
+    platform.mockResolvedValue("windows");
+    await expect(applyModpack("pack")).rejects.toThrow("boom");
+    expect(openExternal).toHaveBeenCalledWith(
+      expect.stringContaining("Fixing-Windows-issues"),
+    );
+  });
+
+  it("does not open the help page on non-Windows platforms", async () => {
+    invoke.mockRejectedValue(new Error("boom"));
+    platform.mockResolvedValue("linux");
+    await expect(applyModpack("pack")).rejects.toThrow("boom");
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("shareModpack", () => {
+  it("builds the share URL from the returned code and copies it", async () => {
+    invoke.mockResolvedValue({ code: 1234567 });
+    await shareModpack("pack");
+    expect(writeClipboardText).toHaveBeenCalledWith(
+      "https://usequadrant.dev/modpack/1234567",
+    );
+  });
+});
+
+describe("exportModpack", () => {
+  it("aborts when the save dialog is cancelled", async () => {
+    openDialog.mockResolvedValue(null);
+    await exportModpack("pack");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("invokes export with the chosen destination", async () => {
+    openDialog.mockResolvedValue("/tmp/pack.zip");
+    invoke.mockResolvedValue(undefined);
+    await exportModpack("pack");
+    expect(invoke).toHaveBeenCalledWith("export_modpack_to", {
+      modpack: "pack",
+      destination: "/tmp/pack.zip",
+    });
+  });
+});
+
+describe("shuffle", () => {
+  it("permutes in place, preserving the multiset of elements", () => {
+    const arr = Array.from({ length: 50 }, (_, i) => i);
+    const copy = [...arr];
+    shuffle(arr);
+    expect(arr).toHaveLength(copy.length);
+    expect([...arr].sort((a, b) => a - b)).toEqual(copy);
+  });
+});

--- a/src/uiScale.test.ts
+++ b/src/uiScale.test.ts
@@ -1,0 +1,55 @@
+/** @format */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  COMPACT_UI_SCALE,
+  MAX_UI_SCALE,
+  MIN_UI_SCALE,
+  applyUiScale,
+  clampUiScale,
+  getAppliedUiScale,
+} from "./uiScale";
+
+afterEach(() => {
+  document.documentElement.style.fontSize = "";
+});
+
+describe("clampUiScale", () => {
+  it("returns the compact default for non-numeric input", () => {
+    expect(clampUiScale(null)).toBe(COMPACT_UI_SCALE);
+    expect(clampUiScale(undefined)).toBe(COMPACT_UI_SCALE);
+    expect(clampUiScale(Number.NaN)).toBe(COMPACT_UI_SCALE);
+    expect(clampUiScale(Number.POSITIVE_INFINITY)).toBe(COMPACT_UI_SCALE);
+    expect(clampUiScale(Number.NEGATIVE_INFINITY)).toBe(COMPACT_UI_SCALE);
+  });
+
+  it("clamps to the allowed range", () => {
+    expect(clampUiScale(0)).toBe(MIN_UI_SCALE);
+    expect(clampUiScale(-500)).toBe(MIN_UI_SCALE);
+    expect(clampUiScale(10_000)).toBe(MAX_UI_SCALE);
+    expect(clampUiScale(MIN_UI_SCALE)).toBe(MIN_UI_SCALE);
+    expect(clampUiScale(MAX_UI_SCALE)).toBe(MAX_UI_SCALE);
+  });
+
+  it("rounds fractional scales", () => {
+    expect(clampUiScale(99.4)).toBe(99);
+    expect(clampUiScale(99.5)).toBe(100);
+  });
+});
+
+describe("applyUiScale / getAppliedUiScale", () => {
+  it("round-trips a scale through the root font size", () => {
+    applyUiScale(150);
+    expect(document.documentElement.style.fontSize).toBe("21px");
+    expect(getAppliedUiScale()).toBe(150);
+  });
+
+  it("applies the clamped value for out-of-range input", () => {
+    applyUiScale(9999);
+    expect(getAppliedUiScale()).toBe(MAX_UI_SCALE);
+  });
+
+  it("falls back to the compact default when nothing is applied", () => {
+    expect(getAppliedUiScale()).toBe(COMPACT_UI_SCALE);
+  });
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+/** @format */
+
+import { defineConfig } from "vitest/config";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
+
+// Standalone test config on purpose: the app's vite.config.ts carries
+// Tauri-specific server settings (fixed port, HMR host) that don't apply here.
+export default defineConfig({
+  plugins: [react({ babel: { presets: [reactCompilerPreset()] } })],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["src/test/setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
Establish a real test strategy across both sides of the app (see TESTING.md).

Rust (quadrant-core / quadrant-host):
- Lift ungated env!() OAuth credentials out of account/id.rs so quadrant-core compiles and tests credential-free (callers use the existing _with_refresh seam).
- Extract a pure rss::parse_feed(bytes, now) and a #[cfg(test)] cache-dir override seam in mc_mod/cache.rs.
- Add unit tests for fingerprinting, model conversions/serde, modpack name/path validation, config idempotency, and RSS/cache logic; extend httpmock coverage for the Modrinth/CurseForge providers and account sync, plus JsonFileStore / event-bridge orchestration tests.

Frontend:
- Add Vitest + React Testing Library + jsdom (vitest.config.ts, test scripts).
- Extract pure logic for testability: deepLinks.ts (resolveDeepLink), snackbar.ts, SearchPage/searchLogic.ts, and a __setRuntimeForTests seam — all behavior preserving.
- Add unit tests (i18n key parity, modLoaders, uiScale, tools, deepLinks, snackbar, searchLogic) and component tests (Button, LoaderOption, CurrentModpackPage, Notifications, Settings, ApplyPage, SearchPage).

Tooling / CI:
- validate-desktop.yml now runs test-rust (cargo test + fmt --check + advisory clippy) and test-frontend (lint + vitest) on every PR.
- Pin classic typescript@5.9.3 so ESLint/typescript-eslint works (native TS 7 omits the compiler API the linter loads); honor the underscore-unused-vars convention.