### PR TITLE
Run apt maintainer scripts when restoring cached deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,16 @@ jobs:
           # Arch is part of the cache key so an x64 entry can never be restored
           # onto the arm64 runner.
           version: 1-${{ runner.arch }}
+          # On a cache hit this action only untars package files; without this it
+          # never runs the maintainer scripts, so dpkg-generated state is absent.
+          # The arm64 image ships no GTK 3 runtime, so libgtk-3-0t64 comes from
+          # the cache there and its postinst (which writes
+          # /usr/lib/aarch64-linux-gnu/gtk-3.0/3.0.0/immodules.cache) never runs.
+          # linuxdeploy-plugin-gtk copies that cache into the AppDir and then
+          # sed's it unconditionally, so a missing file aborts the plugin and
+          # `tauri build` fails with the opaque "failed to run linuxdeploy".
+          # x64 is unaffected only because its image preinstalls GTK 3.
+          execute_install_scripts: true
 
       - name: install frontend dependencies (bun)
         run: bun install


### PR DESCRIPTION
The arm64 `publish-tauri` job has failed on every v26.9.0-stable attempt with a one-line error and no linuxdeploy output:

```
Bundling Quadrant_26.9.0-stable_aarch64.AppImage (...)
failed to bundle project: `failed to run linuxdeploy`
```

The arm64 job installed the exact same 301 packages in July's successful v26.8.0-stable release, the difference is how. Commit 18cb6d9 replaced `sudo apt install` with `awalsh128/cache-apt-pkgs-action`, and on a cache hit that action only untars package files: no dpkg registration, no maintainer scripts. The arm64 runner image ships no GTK 3 runtime (x64 preinstalls it), so on arm64 `libgtk-3-0t64` comes from the cache and its postinst never runs:

```sh
# libgtk-3-0t64.postinst, the part that never ran on arm64
if [ -d "$IMMODULES_DIR" ]; then
     /usr/lib/aarch64-linux-gnu/libgtk-3-0t64/gtk-query-immodules-3.0 --update-cache || true
fi
```

Without it `/usr/lib/aarch64-linux-gnu/gtk-3.0/3.0.0/immodules.cache` does not exist. `linuxdeploy-plugin-gtk` copies the system GTK tree into the AppDir, cannot find `gtk-query-immodules-3.0` (it looks in `libgtk-3-0`, Ubuntu 24.04 ships it under `libgtk-3-0t64`), warns, and then `sed -i`s the file it never got, which under `set -e` kills the plugin. Tauri swallows linuxdeploy's stderr at the default log level, which is why CI only shows `failed to run linuxdeploy`.

Reproduced on a clean Ubuntu 24.04 host by extracting the same packages file-only, which fails identically:

```
[gtk/stderr] sed: can't read AppDir//usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules.cache: No such file or directory
[gtk/stdout] WARNING: gtk-query-immodules-3.0 not found
[gtk/stdout] WARNING: immodules.cache file is missing
ERROR: Failed to run plugin: gtk (exit code: 2)
```

Running the cached `postinst configure` on that same host regenerates `immodules.cache` and the AppImage then builds (exit 0), so the fix is to let the action run the maintainer scripts it caches:

```yaml
      - name: install dependencies (ubuntu only)
        uses: awalsh128/cache-apt-pkgs-action@v1
        with:
          packages: libwebkit2gtk-4.1-dev xdg-utils ...
          version: 1-${{ runner.arch }}
          execute_install_scripts: true
```

The action runs each script with `|| true`, so a script that misbehaves outside its dpkg environment cannot fail the step.

Two notes. Adding packages in 008b0a6 changes the cache key, so the next release would have missed the cache, done a real `apt install` and passed, then repopulated the cache and failed again on the release after that. And `validate-desktop.yml` uses the same action but never bundles an AppImage, so it is left alone; only the release path needs the configured GTK stack. Because `release.yml` only triggers on tags, PR CI cannot exercise this change, hence the local reproduction above.