### PR TITLE
Install Linux CI deps with apt, drop package cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,12 +93,9 @@ jobs:
 
       - name: install dependencies (ubuntu only)
         if: contains(matrix.platform, 'ubuntu')
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: libwebkit2gtk-4.1-dev xdg-utils libappindicator3-dev librsvg2-dev patchelf libsecret-1-dev
-          # Arch is part of the cache key so an x64 entry can never be restored
-          # onto the arm64 runner.
-          version: 1-${{ runner.arch }}
+        run: |
+          sudo apt update
+          sudo apt install -y libwebkit2gtk-4.1-dev xdg-utils libappindicator3-dev librsvg2-dev patchelf libsecret-1-dev
 
       - name: install frontend dependencies (bun)
         run: bun install

--- a/.github/workflows/validate-desktop.yml
+++ b/.github/workflows/validate-desktop.yml
@@ -82,12 +82,9 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install Linux desktop dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: libwebkit2gtk-4.1-dev xdg-utils libappindicator3-dev librsvg2-dev patchelf libsecret-1-dev
-          # Arch is part of the cache key so an x64 entry can never be restored
-          # onto an arm64 runner.
-          version: 1-${{ runner.arch }}
+        run: |
+          sudo apt update
+          sudo apt install -y libwebkit2gtk-4.1-dev xdg-utils libappindicator3-dev librsvg2-dev patchelf libsecret-1-dev
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -161,12 +158,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux desktop dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: libwebkit2gtk-4.1-dev xdg-utils libappindicator3-dev librsvg2-dev patchelf libsecret-1-dev appstream desktop-file-utils
-          # Arch is part of the cache key so an x64 entry can never be restored
-          # onto an arm64 runner.
-          version: 1-${{ runner.arch }}
+        run: |
+          sudo apt update
+          sudo apt install -y libwebkit2gtk-4.1-dev xdg-utils libappindicator3-dev librsvg2-dev patchelf libsecret-1-dev appstream desktop-file-utils
 
       - name: Validate Linux metadata
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace `awalsh128/cache-apt-pkgs-action` with plain `sudo apt update` / `sudo apt install -y` in `validate-desktop.yml` and `release.yml`. Do not cache the packages.

The cache action restores `.deb` files without registering them through dpkg or running maintainer scripts. On arm64 that left GTK’s `immodules.cache` missing, so `linuxdeploy-plugin-gtk` failed while bundling the AppImage (`failed to run linuxdeploy`). A real `apt install` runs those scripts and configures the packages fully.

Package lists are unchanged:
- test-rust / release: `libwebkit2gtk-4.1-dev xdg-utils libappindicator3-dev librsvg2-dev patchelf libsecret-1-dev`
- validate: the same set plus `appstream desktop-file-utils`

Rust crate caching (`Swatinem/rust-cache`) is unaffected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70899ae5-12f6-4203-a362-4f6dc2df2cd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70899ae5-12f6-4203-a362-4f6dc2df2cd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

